### PR TITLE
Add GitHub Actions build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: build
+
+# Runs on a fresh, ephemeral GitHub-hosted Ubuntu VM (free + unlimited minutes
+# for public repos). Triggers on pushes to the main branches and on every PR.
+on:
+  push:
+    branches: [master, "cleanup/**"]
+  pull_request:
+
+jobs:
+  cmake:
+    name: CMake build (Release) + smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history + tags so `git describe` can embed the version.
+          fetch-depth: 0
+
+      - name: Configure
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build build -j "$(nproc)"
+
+      - name: Smoke test
+        run: ./bin/quantinemo --version
+
+  make-debug:
+    name: Makefile debug build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: make debug
+        run: make debug
+
+      - name: Smoke test
+        run: ./bin/quantinemo --version

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,10 +85,11 @@ int main (int argc, char **argv)
 	catch(const int value){
 		if(nb_warning) message("\nCaution: %i WARNINGs were raised.", nb_warning);
 		if(nb_error)   message("\nCaution: %i ERRORs were raised.", nb_error);
-		if(value!=1111) message("\nquantiNemo was not able to run successfully!\n");  // error re-throws
-		//else message("\nquantiNemo terminated!\n");
-        returnVal=1;
-        
+		if(value!=1111){
+			message("\nquantiNemo was not able to run successfully!\n");  // error re-throws
+			returnVal=1;
+		}
+		// value==1111 is an intentional stop (e.g. --version / --help): exit 0
 	}
 	catch(...){
 		if(nb_warning) message("\nCaution: %i WARNINGs were raised.", nb_warning);


### PR DESCRIPTION
CI on ubuntu-latest, triggered on pushes to master/cleanup branches and on all PRs. Two jobs: a CMake Release build and a Makefile `make debug` build, each followed by a `quantinemo --version` smoke test. fetch-depth: 0 so `git describe` can embed the version. Free for this public repo.