### PR TITLE
Return exit code 0 on intentional stop (--version / --help)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,10 +85,11 @@ int main (int argc, char **argv)
 	catch(const int value){
 		if(nb_warning) message("\nCaution: %i WARNINGs were raised.", nb_warning);
 		if(nb_error)   message("\nCaution: %i ERRORs were raised.", nb_error);
-		if(value!=1111) message("\nquantiNemo was not able to run successfully!\n");  // error re-throws
-		//else message("\nquantiNemo terminated!\n");
-        returnVal=1;
-        
+		if(value!=1111){
+			message("\nquantiNemo was not able to run successfully!\n");  // error re-throws
+			returnVal=1;
+		}
+		// value==1111 is an intentional stop (e.g. --version / --help): exit 0
 	}
 	catch(...){
 		if(nb_warning) message("\nCaution: %i WARNINGs were raised.", nb_warning);


### PR DESCRIPTION
The version/help path throws the sentinel value 1111 to unwind, which is caught in main() alongside genuine error throws. returnVal was set to 1 for every int throw, so a successful `quantinemo --version` (or --help) exited non-zero.

Only treat non-1111 throws as failures; 1111 is an intentional, successful stop and now exits 0. Lets scripts and CI smoke tests rely on the exit code.