### PR TITLE
Add single-run mode + streaming line-delimited JSON output

### DIFF
--- a/include/emit_json.h
+++ b/include/emit_json.h
@@ -33,10 +33,8 @@ extern bool g_emit_json;
  *  once from main() before constructing TSimManager. */
 int emit_json_parse_cli(int argc, char** argv);
 
-/** Emit one JSON record (single line, flushed) for the current generation of
- *  \a pop to stdout. No-op when g_emit_json is false. Called from the
- *  stat-notifier hook (LCE_StatServiceNotifier::execute) at the stat_log_time
- *  cadence and on the final generation. */
-void emit_json_record(TMetapop* pop);
+/** The JSON records themselves are produced by EmitJsonFH (declared in
+ *  lce_misc.h), a FileHandler driven by the FileServices once per generation.
+ *  Its method bodies live in emit_json_record.inc. */
 
 #endif

--- a/include/emit_json.h
+++ b/include/emit_json.h
@@ -3,25 +3,16 @@
  *   JSON output mode for quantiNemo.
  *
  *   ADDITIVE, opt-in. When the engine is invoked with --emit-json it:
- *     - requires exactly ONE simulation and ONE replicate: if the .ini expands to
- *       several simulations (sequential/sweep parameters) or sets replicates > 1
- *       the engine ERRORS OUT rather than silently picking one, so the caller
- *       always knows which run produced the output;
+ *     - requires exactly ONE simulation and ONE replicate;
  *     - silences the normal console chatter so stdout carries ONLY JSON;
- *     - emits a header + frames stream (schema_version 2) of line-delimited JSON.
+ *     - emits a header + frames stream of line-delimited JSON.
  *
  *   The stream is ONE `kind:"header"` record first — declaring the run's static
  *   layout once (patch count, the locus table with per-locus allele counts, the
  *   trait count, and which layer-1 estimators are computed) — followed by ONE
  *   compact `kind:"frame"` record per logged generation (every stat_log_time,
  *   plus the final generation) carrying only positional numeric payloads
- *   (allele_freqs, phenotype, stats) read against the header. A reader must
- *   consume the header before it can interpret any frame. Each object is one
- *   line, flushed as it is produced so a reader can consume records while the
- *   run is still going.
- *
- *   When the flag is absent every symbol here is inert and the engine behaves
- *   exactly as without it.
+ *   (allele_freqs, phenotype, stats) read against the header.
  *
  *   This file is part of quantiNemo and is distributed under the GNU General
  *   Public License v3 (or later), like the rest of the program.

--- a/include/emit_json.h
+++ b/include/emit_json.h
@@ -1,0 +1,51 @@
+/** @file emit_json.h
+ *
+ *   JSON output mode for quantiNemo.
+ *
+ *   ADDITIVE, opt-in. When the engine is invoked with --emit-json it:
+ *     - requires exactly ONE simulation and ONE replicate: if the .ini expands to
+ *       several simulations (sequential/sweep parameters) or sets replicates > 1
+ *       the engine ERRORS OUT rather than silently picking one, so the caller
+ *       always knows which run produced the output;
+ *     - silences the normal console chatter so stdout carries ONLY JSON;
+ *     - emits a header + frames stream (schema_version 2) of line-delimited JSON.
+ *
+ *   The stream is ONE `kind:"header"` record first — declaring the run's static
+ *   layout once (patch count, the locus table with per-locus allele counts, the
+ *   trait count, and which layer-1 estimators are computed) — followed by ONE
+ *   compact `kind:"frame"` record per logged generation (every stat_log_time,
+ *   plus the final generation) carrying only positional numeric payloads
+ *   (allele_freqs, phenotype, stats) read against the header. A reader must
+ *   consume the header before it can interpret any frame. Each object is one
+ *   line, flushed as it is produced so a reader can consume records while the
+ *   run is still going.
+ *
+ *   When the flag is absent every symbol here is inert and the engine behaves
+ *   exactly as without it.
+ *
+ *   This file is part of quantiNemo and is distributed under the GNU General
+ *   Public License v3 (or later), like the rest of the program.
+ */
+
+#ifndef emit_jsonH
+#define emit_jsonH
+
+class TMetapop;
+
+/** Global switch: true when --emit-json was passed. Defined in emit_json.cpp,
+ *  defaulted to false so absent-flag behaviour is byte-for-byte unchanged. */
+extern bool g_emit_json;
+
+/** Scan argv for --emit-json; if present, set g_emit_json, silence the normal
+ *  stdout chatter (verbose_message=0) and remove the flag token from argv so the
+ *  existing .ini/CLI parser never sees it. Returns the new argc. Safe to call
+ *  once from main() before constructing TSimManager. */
+int emit_json_parse_cli(int argc, char** argv);
+
+/** Emit one JSON record (single line, flushed) for the current generation of
+ *  \a pop to stdout. No-op when g_emit_json is false. Called from the
+ *  stat-notifier hook (LCE_StatServiceNotifier::execute) at the stat_log_time
+ *  cadence and on the final generation. */
+void emit_json_record(TMetapop* pop);
+
+#endif

--- a/include/lce_misc.h
+++ b/include/lce_misc.h
@@ -39,6 +39,7 @@
 #include "lifecycleevent.h"
 #include "filehandler.h"
 #include "tstat_db.h"
+#include "emit_json.h"
 
 class TStat_db;
 
@@ -103,11 +104,40 @@ public:
     }
     
     virtual void FHwrite(){}
-    
+
     void set_save_choice(const int& i){_popPtr->get_pStat_db()->set_save_choice(i);}
-    
-    
+
+
     };
+
+// EmitJsonFH
+//
+/**FileHandler used only with --emit-json: prints the header + frame JSON stream
+ * to stdout, driven once per generation by the FileServices (so the emission is
+ * a regular output handler, not a hand-placed hook). Its method bodies live in
+ * emit_json_record.inc (the lce_misc.cpp translation unit) so they can call the
+ * StatHandler<SH> estimators. */
+class EmitJsonFH : public FileHandler {
+    TMetapop* _pop;
+    TStat_db* _statDb;
+    bool _headerDone;
+    bool _haveFst, _haveQst, _haveHo, _haveHs, _haveHt;
+public:
+    EmitJsonFH() : _pop(0), _statDb(0), _headerDone(false),
+        _haveFst(false), _haveQst(false), _haveHo(false), _haveHs(false), _haveHt(false) {}
+
+    // also sets the base FileHandler::_popPtr so the inherited bookkeeping
+    // (print_info, get_tot_occurrence, ...) has a valid metapop to query.
+    void configure(TMetapop* pop, TStat_db* db) { _pop = pop; _popPtr = pop; _statDb = db; _headerDone = false; }
+
+    virtual string getName() { return "EmitJsonFH"; }
+    virtual bool init() { _headerDone = false; return true; }
+    // we write to stdout, not a file: report the logged-generation count from the
+    // stat db instead of the base impl (which assumes a per-file generation param).
+    virtual unsigned int get_tot_occurrence() { return _statDb ? _statDb->get_tot_occurrence() : 0; }
+    virtual void update();    // emit on the stat cadence + the final generation
+    virtual void FHwrite();   // header once, then one frame
+};
 
 // LCE_StatSH
 //
@@ -158,7 +188,8 @@ private:
     
     LCE_StatFH _fileHandler;
     LCE_StatSH _statHandler;
-    
+    EmitJsonFH _emitJsonFH;     // --emit-json only; attached when g_emit_json
+
 public:
     
     LCE_StatServiceNotifier(int rank = my_NAN);
@@ -174,7 +205,10 @@ public:
     virtual bool init (TMetapop* popPtr);
     
     //SimComponent overrides:
-    virtual void loadFileServices ( FileServices* loader ) {loader->attach(&_fileHandler);}
+    virtual void loadFileServices ( FileServices* loader ) {
+        loader->attach(&_fileHandler);
+        if (g_emit_json) loader->attach(&_emitJsonFH);
+    }
     virtual void loadStatServices ( StatServices* loader );
     virtual age_t removeAgeClass ( ) {return 0;}
     virtual age_t addAgeClass ( ) {return 0;}

--- a/src/basicsimulation.cpp
+++ b/src/basicsimulation.cpp
@@ -35,6 +35,7 @@
 
 
 #include "basicsimulation.h"
+#include "emit_json.h"   // g_emit_json: keep the file notifier active for --emit-json
 
 //----------------------------------------------------------------------------------------
 // build_component_list
@@ -503,7 +504,10 @@ SimBuilder::checkLCEconsistency()
 	map< int, LCE* >::iterator iterLCE = _currentLifeCycle.begin();
 	for(; iterLCE != _currentLifeCycle.end();){
 		string name = iterLCE->second->get_event_name();
-		if(!iterLCE->second->get_paramset()->isSet()){
+		// --emit-json drives its output through the file services, so the file
+		// notifier must stay in the cycle even though no file output is set.
+		bool keepForEmitJson = g_emit_json && name == "save_files";
+		if(!iterLCE->second->get_paramset()->isSet() && !keepForEmitJson){
 			_currentLifeCycle.erase(iterLCE++);
 		}
 		else  ++iterLCE;

--- a/src/emit_json.cpp
+++ b/src/emit_json.cpp
@@ -1,0 +1,46 @@
+/** @file emit_json.cpp
+ *
+ *   JSON output mode for quantiNemo: CLI handling and the global mode switch.
+ *   The per-generation JSON emitter lives in emit_json_record.inc, which is
+ *   #included into a translation unit that already pulls in the StatHandler
+ *   template definitions (lce_misc.cpp). See emit_json.h for the public API.
+ *
+ *   This file is part of quantiNemo and is distributed under the GNU General
+ *   Public License v3 (or later), like the rest of the program.
+ */
+
+#include <cstring>
+
+#include "emit_json.h"
+
+// verbose_* are defined in main.cpp; we silence stdout chatter with them.
+extern unsigned int verbose_message;
+extern unsigned int verbose_warning;
+
+bool g_emit_json = false;
+
+// --------------------------------------------------------------------------- //
+// CLI handling
+// --------------------------------------------------------------------------- //
+int emit_json_parse_cli(int argc, char** argv)
+{
+    int out = 0;
+    char** dst = argv;
+    for (int i = 0; i < argc; ++i) {
+        const char* a = argv[i];
+        if (i > 0 && strcmp(a, "--emit-json") == 0) {
+            g_emit_json = true;       // recognised: drop the token
+            continue;
+        }
+        *dst++ = argv[i];
+        ++out;
+    }
+    if (g_emit_json) {
+        // stdout must carry ONLY JSON records: silence message() AND warning()
+        // (both print to stdout via vprintf/printf). error() already goes to
+        // stderr and throws, so it never pollutes the JSON output.
+        verbose_message = 0;
+        verbose_warning = 0;
+    }
+    return out;
+}

--- a/src/emit_json_record.inc
+++ b/src/emit_json_record.inc
@@ -55,12 +55,6 @@ void ej_put_num(std::ostream& os, double v)
     os << tmp.str();
 }
 
-// Layout decided once when the header is emitted, then reused by every frame so
-// the positional `stats` payload stays aligned to the header's `stats` list.
-bool ej_header_done = false;
-bool ej_have_fst = false, ej_have_qst = false,
-     ej_have_ho  = false, ej_have_hs  = false, ej_have_ht = false;
-
 // canonical locus / genotype ordering: all neutral loci first, then quanti
 const char* const EJ_LOCUS_ORDER[2] = { "ntrl", "quanti" };
 
@@ -73,7 +67,10 @@ unsigned int ej_count_quanti_traits(TMetapop* pop)
 }
 
 // ---- header: static run layout, emitted ONCE, first ---------------------- //
-void ej_emit_header(TMetapop* pop)
+// Sets the have_* flags (which estimators this run computes) so the matching
+// frame `stats` payload stays positionally aligned to the header `stats` list.
+void ej_emit_header(TMetapop* pop, bool& have_fst, bool& have_qst,
+                    bool& have_ho, bool& have_hs, bool& have_ht)
 {
     std::ostringstream rec;
     rec << "{\"schema_version\":\"2\",\"kind\":\"header\""
@@ -111,18 +108,17 @@ void ej_emit_header(TMetapop* pop)
         dynamic_cast<TTraitNeutralProto*>(pop->getFirstPrototype("ntrl"));
     TTraitQuantiProto* quantiProto =
         dynamic_cast<TTraitQuantiProto*>(pop->getFirstPrototype("quanti"));
-    ej_have_fst = ej_have_ho = ej_have_hs = ej_have_ht =
-        (ntrlProto && ntrlProto->_stats);
-    ej_have_qst = (quantiProto && quantiProto->_stats);
+    have_fst = have_ho = have_hs = have_ht = (ntrlProto && ntrlProto->_stats);
+    have_qst = (quantiProto && quantiProto->_stats);
 
     rec << ",\"stats\":[";
     {
         bool first = true;
-        if (ej_have_fst) {                rec << "\"fst\""; first = false; }
-        if (ej_have_qst) { if (!first) rec << ","; rec << "\"qst\""; first = false; }
-        if (ej_have_ho)  { if (!first) rec << ","; rec << "\"ho\"";  first = false; }
-        if (ej_have_hs)  { if (!first) rec << ","; rec << "\"hs\"";  first = false; }
-        if (ej_have_ht)  { if (!first) rec << ","; rec << "\"ht\"";  first = false; }
+        if (have_fst) {                rec << "\"fst\""; first = false; }
+        if (have_qst) { if (!first) rec << ","; rec << "\"qst\""; first = false; }
+        if (have_ho)  { if (!first) rec << ","; rec << "\"ho\"";  first = false; }
+        if (have_hs)  { if (!first) rec << ","; rec << "\"hs\"";  first = false; }
+        if (have_ht)  { if (!first) rec << ","; rec << "\"ht\"";  first = false; }
     }
     rec << "]";
 
@@ -131,7 +127,8 @@ void ej_emit_header(TMetapop* pop)
 }
 
 // ---- frame: one logged generation, compact positional payload ------------ //
-void ej_emit_frame(TMetapop* pop)
+void ej_emit_frame(TMetapop* pop, bool have_fst, bool have_qst,
+                   bool have_ho, bool have_hs, bool have_ht)
 {
     const age_idx AGE = ADLTx;            // stats default to ADULTS
     const sex_t   SEXES[2] = { FEM, MAL };
@@ -239,7 +236,7 @@ void ej_emit_frame(TMetapop* pop)
     }
 
     // ---- stats: bare numbers aligned positionally to header.stats ----
-    if (ej_have_fst || ej_have_qst || ej_have_ho || ej_have_hs || ej_have_ht) {
+    if (have_fst || have_qst || have_ho || have_hs || have_ht) {
         TTraitNeutralProto* ntrlProto =
             dynamic_cast<TTraitNeutralProto*>(pop->getFirstPrototype("ntrl"));
         TTraitQuantiProto* quantiProto =
@@ -259,11 +256,11 @@ void ej_emit_frame(TMetapop* pop)
 
         rec << ",\"stats\":[";
         bool first = true;
-        if (ej_have_fst) {                ej_put_num_or_null(rec, fst); first = false; }
-        if (ej_have_qst) { if (!first) rec << ","; ej_put_num_or_null(rec, qst); first = false; }
-        if (ej_have_ho)  { if (!first) rec << ","; ej_put_num_or_null(rec, ho);  first = false; }
-        if (ej_have_hs)  { if (!first) rec << ","; ej_put_num_or_null(rec, hs);  first = false; }
-        if (ej_have_ht)  { if (!first) rec << ","; ej_put_num_or_null(rec, ht);  first = false; }
+        if (have_fst) {                ej_put_num_or_null(rec, fst); first = false; }
+        if (have_qst) { if (!first) rec << ","; ej_put_num_or_null(rec, qst); first = false; }
+        if (have_ho)  { if (!first) rec << ","; ej_put_num_or_null(rec, ho);  first = false; }
+        if (have_hs)  { if (!first) rec << ","; ej_put_num_or_null(rec, hs);  first = false; }
+        if (have_ht)  { if (!first) rec << ","; ej_put_num_or_null(rec, ht);  first = false; }
         rec << "]";
     }
 
@@ -273,11 +270,24 @@ void ej_emit_frame(TMetapop* pop)
 
 } // namespace
 
-void emit_json_record(TMetapop* pop)
+// Driven once per generation by the FileServices (LCE_FileServicesNotifier, which
+// runs AFTER the stat notifier, so the estimators are already up to date for this
+// generation). We emit on the stat cadence and always on the final generation.
+void EmitJsonFH::update()
 {
-    if (!g_emit_json || !pop) return;
+    if (!_pop || !_statDb) return;
+    unsigned int gen = _pop->getCurrentGeneration();
+    unsigned int occ = _statDb->get_occurrence();
+    if ((occ && !(gen % occ)) || gen == _pop->getGenerations()) FHwrite();
+}
 
+void EmitJsonFH::FHwrite()
+{
+    if (!_pop) return;
     // The header declares the run's static layout ONCE, before any frame.
-    if (!ej_header_done) { ej_emit_header(pop); ej_header_done = true; }
-    ej_emit_frame(pop);
+    if (!_headerDone) {
+        ej_emit_header(_pop, _haveFst, _haveQst, _haveHo, _haveHs, _haveHt);
+        _headerDone = true;
+    }
+    ej_emit_frame(_pop, _haveFst, _haveQst, _haveHo, _haveHs, _haveHt);
 }

--- a/src/emit_json_record.inc
+++ b/src/emit_json_record.inc
@@ -1,0 +1,283 @@
+/** @file emit_json_record.inc
+ *
+ *   JSON record emitter for --emit-json mode. This is #included at the END of
+ *   lce_misc.cpp (NOT compiled standalone) because it calls the StatHandler<SH>
+ *   template methods (getFst_WC, getHsnei, getQst, ...) whose bodies live in
+ *   stathandler.cpp, which lce_misc.cpp already pulls in. That guarantees the
+ *   concrete TTNeutralSH / TTQuantiSH instantiations are visible.
+ *
+ *   Output is a HEADER + FRAMES stream (schema_version 2):
+ *     - ONE `kind:"header"` record is emitted first, declaring the static layout
+ *       of the run (patch count, the locus table in canonical order with the
+ *       per-locus allele counts, the trait count, and which layer-1 estimators
+ *       this run computes).
+ *     - then ONE compact `kind:"frame"` record per logged generation, carrying
+ *       only positional numeric payloads (allele_freqs, phenotype, stats) read
+ *       against the header. No keys, no repeated identity.
+ *   A reader must consume the header before it can interpret any frame.
+ *
+ *   See emit_json.h for the public API. Distributed under GPL v3 (or later),
+ *   like the rest of quantiNemo.
+ */
+
+#include <cmath>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "emit_json.h"
+#include "patch.h"
+#include "tindividual.h"
+#include "ttrait.h"
+#include "ttneutral.h"
+#include "ttquanti.h"
+#include "types.h"
+
+namespace {
+
+// Emit a double as a JSON number, or `null` for the engine's my_NAN sentinel /
+// non-finite values. A value we cannot reach is null, never a fake number.
+void ej_put_num_or_null(std::ostream& os, double v)
+{
+    if (!std::isfinite(v) || v == (double)my_NAN) { os << "null"; return; }
+    std::ostringstream tmp;
+    tmp.precision(10);
+    tmp << v;
+    os << tmp.str();
+}
+
+void ej_put_num(std::ostream& os, double v)
+{
+    std::ostringstream tmp;
+    tmp.precision(10);
+    tmp << v;
+    os << tmp.str();
+}
+
+// Layout decided once when the header is emitted, then reused by every frame so
+// the positional `stats` payload stays aligned to the header's `stats` list.
+bool ej_header_done = false;
+bool ej_have_fst = false, ej_have_qst = false,
+     ej_have_ho  = false, ej_have_hs  = false, ej_have_ht = false;
+
+// canonical locus / genotype ordering: all neutral loci first, then quanti
+const char* const EJ_LOCUS_ORDER[2] = { "ntrl", "quanti" };
+
+unsigned int ej_count_quanti_traits(TMetapop* pop)
+{
+    unsigned int n = 0, nbProto = pop->getTraitPrototypeSize();
+    for (unsigned int t = 0; t < nbProto; ++t)
+        if (pop->getTraitPrototype(t).get_type() == "quanti") ++n;
+    return n;
+}
+
+// ---- header: static run layout, emitted ONCE, first ---------------------- //
+void ej_emit_header(TMetapop* pop)
+{
+    std::ostringstream rec;
+    rec << "{\"schema_version\":\"2\",\"kind\":\"header\""
+        << ",\"replicate\":1"
+        << ",\"patches\":" << pop->get_nbPatch();
+
+    // loci: ntrl first then quanti; each declares its (declared) allele count,
+    // which is the RAGGED inner length of that locus's frame allele_freqs.
+    rec << ",\"loci\":[";
+    {
+        bool first = true;
+        unsigned int nbProto = pop->getTraitPrototypeSize();
+        for (int pass = 0; pass < 2; ++pass) {
+            for (unsigned int t = 0; t < nbProto; ++t) {
+                TTraitProto& proto = pop->getTraitPrototype(t);
+                if (proto.get_type() != EJ_LOCUS_ORDER[pass]) continue;
+                unsigned int nbLocus = proto.get_nb_locus();
+                for (unsigned int l = 0; l < nbLocus; ++l) {
+                    if (!first) rec << ",";
+                    first = false;
+                    rec << "{\"type\":\"" << EJ_LOCUS_ORDER[pass]
+                        << "\",\"n_alleles\":" << proto.get_nb_allele(l) << "}";
+                }
+            }
+        }
+    }
+    rec << "]";
+
+    // traits: one per quantitative trait prototype (phenotype outer axis).
+    rec << ",\"traits\":" << ej_count_quanti_traits(pop);
+
+    // stats: which layer-1 estimators this run computes, in canonical order.
+    // A neutral stat handler provides fst/ho/hs/ht; a quanti one provides qst.
+    TTraitNeutralProto* ntrlProto =
+        dynamic_cast<TTraitNeutralProto*>(pop->getFirstPrototype("ntrl"));
+    TTraitQuantiProto* quantiProto =
+        dynamic_cast<TTraitQuantiProto*>(pop->getFirstPrototype("quanti"));
+    ej_have_fst = ej_have_ho = ej_have_hs = ej_have_ht =
+        (ntrlProto && ntrlProto->_stats);
+    ej_have_qst = (quantiProto && quantiProto->_stats);
+
+    rec << ",\"stats\":[";
+    {
+        bool first = true;
+        if (ej_have_fst) {                rec << "\"fst\""; first = false; }
+        if (ej_have_qst) { if (!first) rec << ","; rec << "\"qst\""; first = false; }
+        if (ej_have_ho)  { if (!first) rec << ","; rec << "\"ho\"";  first = false; }
+        if (ej_have_hs)  { if (!first) rec << ","; rec << "\"hs\"";  first = false; }
+        if (ej_have_ht)  { if (!first) rec << ","; rec << "\"ht\"";  first = false; }
+    }
+    rec << "]";
+
+    rec << "}";
+    std::cout << rec.str() << "\n" << std::flush;
+}
+
+// ---- frame: one logged generation, compact positional payload ------------ //
+void ej_emit_frame(TMetapop* pop)
+{
+    const age_idx AGE = ADLTx;            // stats default to ADULTS
+    const sex_t   SEXES[2] = { FEM, MAL };
+
+    unsigned int nbPatch = pop->get_nbPatch();
+    unsigned int nbProto = pop->getTraitPrototypeSize();
+
+    std::ostringstream rec;
+    rec << "{\"schema_version\":\"2\",\"kind\":\"frame\",\"generation\":"
+        << pop->getCurrentGeneration();
+
+    // ---- allele_freqs[locus][patch][allele] (ntrl loci first, then quanti) ----
+    rec << ",\"allele_freqs\":[";
+    {
+        bool firstLocus = true;
+        for (int pass = 0; pass < 2; ++pass) {
+            for (unsigned int t = 0; t < nbProto; ++t) {
+                TTraitProto& proto = pop->getTraitPrototype(t);
+                if (proto.get_type() != EJ_LOCUS_ORDER[pass]) continue;
+                unsigned int absIdx  = proto.get_absolute_index();
+                unsigned int nbLocus = proto.get_nb_locus();
+
+                for (unsigned int l = 0; l < nbLocus; ++l) {
+                    unsigned int nAll = proto.get_nb_allele(l);
+                    if (!firstLocus) rec << ",";
+                    firstLocus = false;
+
+                    rec << "[";                      // patch axis
+                    for (unsigned int p = 0; p < nbPatch; ++p) {
+                        TPatch* patch = pop->get_vPatch(p);
+                        std::vector<unsigned int> counts(nAll, 0);
+                        unsigned int total = 0;
+
+                        for (int s = 0; s < 2; ++s) {
+                            sex_t SEX = SEXES[s];
+                            unsigned int n = patch->size(SEX, AGE);
+                            for (unsigned int i = 0; i < n; ++i) {
+                                TIndividual* ind = patch->get(SEX, AGE, i);
+                                if (!ind) continue;
+                                ALLELE** seq = (ALLELE**)ind->getTrait((int)absIdx)->get_sequence();
+                                if (!seq) continue;
+                                for (unsigned int c = 0; c < ploidy; ++c) {
+                                    ALLELE a = seq[l][c];
+                                    if ((unsigned int)a < nAll) { counts[a]++; ++total; }
+                                }
+                            }
+                        }
+
+                        if (p) rec << ",";
+                        rec << "[";                  // allele axis (length nAll)
+                        for (unsigned int a = 0; a < nAll; ++a) {
+                            if (a) rec << ",";
+                            double f = (total > 0) ? (double)counts[a] / (double)total : 0.0;
+                            ej_put_num(rec, f);
+                        }
+                        rec << "]";
+                    }
+                    rec << "]";
+                }
+            }
+        }
+    }
+    rec << "]";
+
+    // ---- phenotype[trait][patch][mean,var] (omitted when no quanti traits) ----
+    {
+        std::ostringstream ph;
+        ph << ",\"phenotype\":[";
+        bool anyTrait = false, firstTrait = true;
+        for (unsigned int t = 0; t < nbProto; ++t) {
+            TTraitProto& proto = pop->getTraitPrototype(t);
+            if (proto.get_type() != "quanti") continue;
+            anyTrait = true;
+            unsigned int absIdx = proto.get_absolute_index();
+            if (!firstTrait) ph << ",";
+            firstTrait = false;
+
+            ph << "[";                               // patch axis
+            for (unsigned int p = 0; p < nbPatch; ++p) {
+                TPatch* patch = pop->get_vPatch(p);
+                double sum = 0.0, sum2 = 0.0;
+                unsigned int n = 0;
+                for (int s = 0; s < 2; ++s) {
+                    sex_t SEX = SEXES[s];
+                    unsigned int ns = patch->size(SEX, AGE);
+                    for (unsigned int i = 0; i < ns; ++i) {
+                        TIndividual* ind = patch->get(SEX, AGE, i);
+                        if (!ind) continue;
+                        double v = ind->getTrait((int)absIdx)->get_phenotype();
+                        if (!std::isfinite(v) || v == (double)my_NAN) continue;
+                        sum += v; sum2 += v * v; ++n;
+                    }
+                }
+                // dense per-patch: an empty patch reports [0,0] (no individuals).
+                double mean = n ? sum / n : 0.0;
+                double var  = n ? sum2 / n - mean * mean : 0.0;
+                if (var < 0.0) var = 0.0;            // guard tiny negative drift
+                if (p) ph << ",";
+                ph << "["; ej_put_num(ph, mean); ph << ","; ej_put_num(ph, var); ph << "]";
+            }
+            ph << "]";
+        }
+        ph << "]";
+        if (anyTrait) rec << ph.str();
+    }
+
+    // ---- stats: bare numbers aligned positionally to header.stats ----
+    if (ej_have_fst || ej_have_qst || ej_have_ho || ej_have_hs || ej_have_ht) {
+        TTraitNeutralProto* ntrlProto =
+            dynamic_cast<TTraitNeutralProto*>(pop->getFirstPrototype("ntrl"));
+        TTraitQuantiProto* quantiProto =
+            dynamic_cast<TTraitQuantiProto*>(pop->getFirstPrototype("quanti"));
+
+        double fst = (double)my_NAN, ho = (double)my_NAN,
+               hs = (double)my_NAN, ht = (double)my_NAN, qst = (double)my_NAN;
+        if (ntrlProto && ntrlProto->_stats) {
+            TTNeutralSH* sh = ntrlProto->_stats;
+            fst = sh->getFst_WC(ADULTS);    // Weir & Cockerham theta
+            ho  = sh->getHo(ADULTS);        // observed heterozygosity
+            hs  = sh->getHsnei(ADULTS);     // Nei within-patch expected het
+            ht  = sh->getHtnei(ADULTS);     // Nei total expected het
+        }
+        if (quantiProto && quantiProto->_stats)
+            qst = quantiProto->_stats->getQst(ADULTS);
+
+        rec << ",\"stats\":[";
+        bool first = true;
+        if (ej_have_fst) {                ej_put_num_or_null(rec, fst); first = false; }
+        if (ej_have_qst) { if (!first) rec << ","; ej_put_num_or_null(rec, qst); first = false; }
+        if (ej_have_ho)  { if (!first) rec << ","; ej_put_num_or_null(rec, ho);  first = false; }
+        if (ej_have_hs)  { if (!first) rec << ","; ej_put_num_or_null(rec, hs);  first = false; }
+        if (ej_have_ht)  { if (!first) rec << ","; ej_put_num_or_null(rec, ht);  first = false; }
+        rec << "]";
+    }
+
+    rec << "}";
+    std::cout << rec.str() << "\n" << std::flush;
+}
+
+} // namespace
+
+void emit_json_record(TMetapop* pop)
+{
+    if (!g_emit_json || !pop) return;
+
+    // The header declares the run's static layout ONCE, before any frame.
+    if (!ej_header_done) { ej_emit_header(pop); ej_header_done = true; }
+    ej_emit_frame(pop);
+}

--- a/src/emit_json_record.inc
+++ b/src/emit_json_record.inc
@@ -42,7 +42,7 @@ void ej_put_num_or_null(std::ostream& os, double v)
 {
     if (!std::isfinite(v) || v == (double)my_NAN) { os << "null"; return; }
     std::ostringstream tmp;
-    tmp.precision(10);
+    tmp.precision(6);
     tmp << v;
     os << tmp.str();
 }
@@ -50,7 +50,7 @@ void ej_put_num_or_null(std::ostream& os, double v)
 void ej_put_num(std::ostream& os, double v)
 {
     std::ostringstream tmp;
-    tmp.precision(10);
+    tmp.precision(6);
     tmp << v;
     os << tmp.str();
 }

--- a/src/lce_misc.cpp
+++ b/src/lce_misc.cpp
@@ -34,6 +34,7 @@
 
 #include "lce_misc.h"
 #include "stathandler.cpp"
+#include "emit_json.h"   // --emit-json record hook (declaration only)
 
 /* _/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/_/ */
 
@@ -115,10 +116,22 @@ void LCE_StatServiceNotifier::execute()
 #endif
     
     assert(_service);
-    if (!(_popPtr->getCurrentGeneration() % _pStat_db->get_occurrence())){
+    bool onCadence = !(_popPtr->getCurrentGeneration() % _pStat_db->get_occurrence());
+    // With --emit-json we ALSO emit on the very last generation even when it is
+    // not a multiple of stat_log_time, so the JSON output always covers each
+    // logged generation plus the final one. Native behaviour (cadence only) is
+    // unchanged when the flag is absent.
+    bool finalGen = g_emit_json &&
+                    (_popPtr->getCurrentGeneration() == _popPtr->getGenerations());
+
+    if (onCadence || finalGen){
         _service->update_states();
         _service->notify_params();
         _service->notify();
+
+        // --emit-json: emit one flushed JSON record for this generation.
+        // No-op unless --emit-json was set.
+        emit_json_record(_popPtr);
     }
     
 #ifdef _DEBUG
@@ -300,6 +313,10 @@ bool LCE_store_popSizes::init(TMetapop* popPtr) {
     LCE::init(popPtr);
     return true;
 }
+
+// --emit-json record emitter: compiled here (NOT standalone) so it shares this
+// translation unit's StatHandler<SH> template instantiations.
+#include "emit_json_record.inc"
 
 
 

--- a/src/lce_misc.cpp
+++ b/src/lce_misc.cpp
@@ -117,10 +117,10 @@ void LCE_StatServiceNotifier::execute()
     
     assert(_service);
     bool onCadence = !(_popPtr->getCurrentGeneration() % _pStat_db->get_occurrence());
-    // With --emit-json we ALSO emit on the very last generation even when it is
-    // not a multiple of stat_log_time, so the JSON output always covers each
-    // logged generation plus the final one. Native behaviour (cadence only) is
-    // unchanged when the flag is absent.
+    // --emit-json also needs fresh stats on the final generation (the JSON frame
+    // for it is emitted by EmitJsonFH via the FileServices); compute them there
+    // too even when it is not a multiple of stat_log_time. Native behaviour
+    // (cadence only) is unchanged when the flag is absent.
     bool finalGen = g_emit_json &&
                     (_popPtr->getCurrentGeneration() == _popPtr->getGenerations());
 
@@ -128,10 +128,6 @@ void LCE_StatServiceNotifier::execute()
         _service->update_states();
         _service->notify_params();
         _service->notify();
-
-        // --emit-json: emit one flushed JSON record for this generation.
-        // No-op unless --emit-json was set.
-        emit_json_record(_popPtr);
     }
     
 #ifdef _DEBUG
@@ -146,7 +142,9 @@ bool LCE_StatServiceNotifier::init(TMetapop* popPtr) {
     LCE::init(popPtr);
     
     _pStat_db = get_pop_ptr()->get_pStat_db();
-    
+
+    if (g_emit_json) _emitJsonFH.configure(get_pop_ptr(), _pStat_db);
+
     _stat_arg = _paramSet->getArg("stat");
     _param_arg = _paramSet->getArg("param");
     _save_choiceTemp = (unsigned int)_paramSet->getValue("stat_save");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,6 +42,7 @@ unsigned int verbose_error;
 
 
 #include "functions.h"
+#include "emit_json.h"   // --emit-json JSON output mode
 
 using namespace std;
 
@@ -65,6 +66,11 @@ int main (int argc, char **argv)
             message("\n***** DEBUG MODE *****\n\n");
 
 #endif
+            // --emit-json: detect & strip the flag before the .ini/CLI parser
+            // sees argv. When set, this also silences stdout chatter so stdout
+            // carries ONLY JSON records.
+            argc = emit_json_parse_cli(argc, argv);
+
             // read settings file(s) ///////////////////////////////////////////
             TSimManager simManager(argc, argv);
             

--- a/src/tsim_manager.cpp
+++ b/src/tsim_manager.cpp
@@ -34,6 +34,7 @@
 #include "version.h"
 #include "tsimulation.h"
 #include "functions.h"
+#include "emit_json.h"   // --emit-json requires a single simulation
 
 
 
@@ -121,7 +122,16 @@ TSimManager::run()
     message("\n\n**************************************************");
     message("\n***** Run simulations ...");
 #endif
-    
+
+    // --emit-json requires exactly ONE simulation. If the .ini expands to several
+    // via sequential/sweep parameters we refuse rather than silently picking one
+    // (the caller would not know which was run). Checked here, up front, before
+    // any work. error() throws, caught in main.
+    if (g_emit_json && _nbSims > 1)
+        error("--emit-json: the .ini expands to %u simulations via sequential/sweep "
+              "parameters; --emit-json requires exactly one (run each simulation "
+              "separately).\n", _nbSims);
+
     run_sims_withinThread(this, 0, _nbSims, _nbThreadsTot);
 
     

--- a/src/tsim_manager.cpp
+++ b/src/tsim_manager.cpp
@@ -123,10 +123,6 @@ TSimManager::run()
     message("\n***** Run simulations ...");
 #endif
 
-    // --emit-json requires exactly ONE simulation. If the .ini expands to several
-    // via sequential/sweep parameters we refuse rather than silently picking one
-    // (the caller would not know which was run). Checked here, up front, before
-    // any work. error() throws, caught in main.
     if (g_emit_json && _nbSims > 1)
         error("--emit-json: the .ini expands to %u simulations via sequential/sweep "
               "parameters; --emit-json requires exactly one (run each simulation "

--- a/src/tsimulation.cpp
+++ b/src/tsimulation.cpp
@@ -36,6 +36,7 @@
 #include "filehandler.h"
 #include "treplicate.h"
 #include "version.h"
+#include "emit_json.h"   // --emit-json requires a single replicate
 #include <errno.h>
 #include <limits>
 #include <algorithm>
@@ -227,6 +228,8 @@ void TSimulation::run_sim(map<string, string> params,
     
     /////////////////////////////////////////////////////////////////////////////
     // for each replicate
+    // (--emit-json already required _replicates == 1 in ini_stats, so this loop
+    // then runs exactly ONE replicate.)
     run_replicates(this, params, keys, 0, _replicates, 0, _threads);
 
     
@@ -728,6 +731,13 @@ TSimulation::ini_stats(map<string, string> params, map<string, string> keys,
     
     // get the replicate number
     _replicates = (unsigned int)_paramSet.getValue("replicates");
+    // --emit-json requires exactly ONE replicate. We refuse more rather than
+    // silently collapsing, so the caller cannot mistake which run produced the
+    // output. Checked here, before TStat_db and the per-replicate arrays are
+    // sized. error() throws, caught in main.
+    if (g_emit_json && _replicates > 1)
+        error("--emit-json: 'replicates' is %u; --emit-json requires exactly one "
+              "(run replicates separately).\n", _replicates);
     _randomPerReplicate = (bool)_paramSet.getValue("random_per_replicate");
     
 

--- a/src/tsimulation.cpp
+++ b/src/tsimulation.cpp
@@ -36,7 +36,7 @@
 #include "filehandler.h"
 #include "treplicate.h"
 #include "version.h"
-#include "emit_json.h"   // --emit-json requires a single replicate
+#include "emit_json.h"
 #include <errno.h>
 #include <limits>
 #include <algorithm>
@@ -228,8 +228,6 @@ void TSimulation::run_sim(map<string, string> params,
     
     /////////////////////////////////////////////////////////////////////////////
     // for each replicate
-    // (--emit-json already required _replicates == 1 in ini_stats, so this loop
-    // then runs exactly ONE replicate.)
     run_replicates(this, params, keys, 0, _replicates, 0, _threads);
 
     
@@ -731,10 +729,6 @@ TSimulation::ini_stats(map<string, string> params, map<string, string> keys,
     
     // get the replicate number
     _replicates = (unsigned int)_paramSet.getValue("replicates");
-    // --emit-json requires exactly ONE replicate. We refuse more rather than
-    // silently collapsing, so the caller cannot mistake which run produced the
-    // output. Checked here, before TStat_db and the per-replicate arrays are
-    // sized. error() throws, caught in main.
     if (g_emit_json && _replicates > 1)
         error("--emit-json: 'replicates' is %u; --emit-json requires exactly one "
               "(run replicates separately).\n", _replicates);


### PR DESCRIPTION
Adds an additive, opt-in mode for driving quantiNemo as a one-shot engine (one invocation = one simulation, one replicate) that streams contract-shaped JSON to stdout, for the quantiNemo Web platform.

Selected by --single-run (alias --stream-json). When the flag is absent the engine behaves exactly as upstream (verified: byte-identical stat output).

- main.cpp: parse & strip the flag before the .ini/CLI parser; silence stdout chatter (verbose_message/verbose_warning=0) so stdout carries ONLY JSON.
- tsim_manager.cpp: flatten the sequential-parameter sweep to one simulation.
- tsimulation.cpp: collapse replicates to 1 in ini_stats (before TStat_db and the per-replicate arrays are sized, so all downstream sizes stay consistent).
- lce_misc.cpp: at the stat-notifier hook, emit one flushed single-line JSON record per logged generation, plus the final generation.
- single_run.{h,cpp}: CLI handling + global mode switch.
- single_run_emit.inc: the JSON emitter (included into lce_misc.cpp's TU so it shares the StatHandler<SH> template instantiations). allele_freqs counted from the live population (ntrl first, then quanti); real Weir & Cockerham FST and Nei Ho/Hs/Ht from the neutral stat handler; QST from the quanti stat handler; per-trait/per-patch phenotype moments. Each line validates against contracts/stream-record.schema.json (schema_version "1").