### PR TITLE
Fix intermittent segfault during teardown: stat handlers read the metapop after it is freed

### DIFF
--- a/include/stathandler.h
+++ b/include/stathandler.h
@@ -212,7 +212,17 @@ protected:
     _fst[NB_AGE_CLASSES], _fis[NB_AGE_CLASSES], _fit[NB_AGE_CLASSES];
 	double _fst_wc[NB_AGE_CLASSES], _fis_wc[NB_AGE_CLASSES], _fit_wc[NB_AGE_CLASSES];
 	double*** _fst_matrix_wc, ***_fst_matrix;
-    
+
+	// Number of rows each per-age matrix above was allocated with. The number of sampled patches
+	// may change between generations, so the allocation-time count has to be kept around to free
+	// the right number of rows. It also keeps ~StatHandler() from having to ask the metapop, which
+	// may already be destroyed by the time the stat handlers are torn down.
+	unsigned int _alleleFreq_local_rows[NB_AGE_CLASSES];
+	unsigned int _locusFreq_local_rows[NB_AGE_CLASSES];
+	unsigned int _coa_matrix_rows[NB_AGE_CLASSES];
+	unsigned int _fst_matrix_rows[NB_AGE_CLASSES];
+	unsigned int _fst_matrix_wc_rows[NB_AGE_CLASSES];
+
 	double **_hsnei_locus, **_htnei_locus, **_fst_locus, **_fis_locus, **_fit_locus,  // for Nei and Chesser
     **_ho_locus, **_hs_locus, **_ht_locus;
     
@@ -234,7 +244,15 @@ public:
     _hsnei_locus(0), _htnei_locus(0), _fst_locus(0), _fis_locus(0), _fit_locus(0),
     _ho_locus(0), _hs_locus(0), _ht_locus(0), _fst_WC_locus(0), _fis_WC_locus(0), _fit_WC_locus(0),
     _het0_locus(0), _het1_locus(0), _fst_bn_locus(0){
-        
+
+		for(unsigned int a=0; a<NB_AGE_CLASSES; ++a){
+			_alleleFreq_local_rows[a] = 0;
+			_locusFreq_local_rows[a]  = 0;
+			_coa_matrix_rows[a]       = 0;
+			_fst_matrix_rows[a]       = 0;
+			_fst_matrix_wc_rows[a]    = 0;
+		}
+
 		_computed_size = 35;
 		_computed = new unsigned int*[_computed_size];
 		for(unsigned int i=0; i<_computed_size; ++i){

--- a/include/ttquanti.h
+++ b/include/ttquanti.h
@@ -314,13 +314,19 @@ private:
 	double** _qst_matrix;        // Qst matrix for pairwise values
 	double** _qstF_matrix;       // Qst matrix for pairwise values corrected for inbreeding
 
+	// Rows each matrix above was allocated with; the number of sampled patches may change between
+	// generations, and the destructor must not ask the metapop (it is destroyed first).
+	unsigned int _qst_matrix_rows;
+	unsigned int _qstF_matrix_rows;
+
 //	double Theta_FF, Theta_MM, Theta_FM;
 //	double _mean_theta, _mean_alpha;
 
 public:
 
 	TTQuantiSH (TTraitQuantiProto* TT) :  _varA(0), _varA2(0),/* _h2(0),*/ _meanG(0), _varG(0),
-	_meanP(0), _varP(0), _meanW(0), _varW(0), _qst_matrix(0), _qstF_matrix(0)
+	_meanP(0), _varP(0), _meanW(0), _varW(0), _qst_matrix(0), _qstF_matrix(0),
+	_qst_matrix_rows(0), _qstF_matrix_rows(0)
 {
 		set(TT);
 
@@ -343,9 +349,10 @@ public:
 		ARRAY::delete_2D(_varP, 3);
 		ARRAY::delete_2D(_meanW, 3);
 		ARRAY::delete_2D(_varW, 3);
-        assert(_popPtr);
-		ARRAY::delete_2D(_qst_matrix, get_current_nbSamplePatch());
-		ARRAY::delete_2D(_qstF_matrix, get_current_nbSamplePatch());
+		// Free with the row counts recorded at allocation: the metapop is already destroyed here,
+		// so _popPtr dangles and must not be dereferenced.
+		ARRAY::delete_2D(_qst_matrix, _qst_matrix_rows);
+		ARRAY::delete_2D(_qstF_matrix, _qstF_matrix_rows);
 
 	}
 

--- a/src/stathandler.cpp
+++ b/src/stathandler.cpp
@@ -680,17 +680,16 @@ StatHandler<SH>::~StatHandler()
     ARRAY::delete_2D(_het1_locus, NB_AGE_CLASSES);
     ARRAY::delete_2D(_fst_bn_locus, NB_AGE_CLASSES);
     
-    if(_popPtr){
-        if(!get_current_nbSamplePatch()) _popPtr->_current_nbSamplePatch = get_last_nbSamplePatch(); // since the stats were not made at the last generation
-        ARRAY::delete_3D(_fst_matrix_wc, NB_AGE_CLASSES, get_current_nbSamplePatch());
-        ARRAY::delete_3D(_fst_matrix, NB_AGE_CLASSES, get_current_nbSamplePatch());
-        ARRAY::delete_3D(_coa_matrix, NB_AGE_CLASSES, get_current_nbSamplePatch());
-        ARRAY::delete_3D(_alleleFreq_local, NB_AGE_CLASSES, get_current_nbSamplePatch());
-        ARRAY::delete_2D(_alleleFreq_global, NB_AGE_CLASSES);
-        ARRAY::delete_3D(_locusFreq_local, NB_AGE_CLASSES, get_current_nbSamplePatch());
-        ARRAY::delete_2D(_locusFreq_global, NB_AGE_CLASSES);
-    }
-    
+    // Free each per-age matrix with the row count it was allocated with (see the *_rows members).
+    // Nothing here may touch _popPtr: the metapop is destroyed before its stat handlers.
+    ARRAY::delete_3D(_fst_matrix_wc, NB_AGE_CLASSES, _fst_matrix_wc_rows);
+    ARRAY::delete_3D(_fst_matrix, NB_AGE_CLASSES, _fst_matrix_rows);
+    ARRAY::delete_3D(_coa_matrix, NB_AGE_CLASSES, _coa_matrix_rows);
+    ARRAY::delete_3D(_alleleFreq_local, NB_AGE_CLASSES, _alleleFreq_local_rows);
+    ARRAY::delete_2D(_alleleFreq_global, NB_AGE_CLASSES);
+    ARRAY::delete_3D(_locusFreq_local, NB_AGE_CLASSES, _locusFreq_local_rows);
+    ARRAY::delete_2D(_locusFreq_global, NB_AGE_CLASSES);
+
     for (REC_IT pos = _recorders.begin(); pos != _recorders.end(); ++pos) {
         delete *pos;
     }
@@ -932,6 +931,7 @@ StatHandler<SH>::set_alleleFreq(const age_idx & AGE)
     if (!_alleleFreq_global[AGE]) { // first time this age class
         ARRAY::create_1D<map<ALLELE, double> >(_alleleFreq_global[AGE], _nb_locus); // [age][locus][allele]
         ARRAY::create_2D<map<ALLELE, double> >(_alleleFreq_local[AGE],get_current_nbSamplePatch(), _nb_locus); // [age][sampleID][locus][allele]
+        _alleleFreq_local_rows[AGE] = get_current_nbSamplePatch();
     }
     else { // reset
         // global freqs
@@ -941,8 +941,9 @@ StatHandler<SH>::set_alleleFreq(const age_idx & AGE)
         
         // local freqs
         if (get_current_nbSamplePatch() != get_last_nbSamplePatch()) { // number of sampled and populated patches change over time
-            ARRAY::delete_2D<map<ALLELE, double> >(_alleleFreq_local[AGE],get_last_nbSamplePatch());
+            ARRAY::delete_2D<map<ALLELE, double> >(_alleleFreq_local[AGE],_alleleFreq_local_rows[AGE]);
             ARRAY::create_2D<map<ALLELE, double> >(_alleleFreq_local[AGE],get_current_nbSamplePatch(), _nb_locus); // [age][sampleID][locus][allele]
+            _alleleFreq_local_rows[AGE] = get_current_nbSamplePatch();
         }
         else { // the number of sampled patches has not changed
             for (p = 0; p < get_current_nbSamplePatch(); ++p) {
@@ -1002,6 +1003,7 @@ StatHandler<SH>::set_locusFreq(const age_idx & AGE)
     if (!_locusFreq_global[AGE]) { // first time this age class
         ARRAY::create_1D<map<ALLELE, map<ALLELE, double> > >(_locusFreq_global[AGE], _nb_locus); // [age][locus][allele]
         ARRAY::create_2D<map<ALLELE, map<ALLELE, double> > >(_locusFreq_local[AGE],	get_current_nbSamplePatch(), _nb_locus); // [age][sampleID][locus][allele]
+        _locusFreq_local_rows[AGE] = get_current_nbSamplePatch();
     }
     else { // reset
         // global freqs
@@ -1011,8 +1013,9 @@ StatHandler<SH>::set_locusFreq(const age_idx & AGE)
         
         // local freqs
         if (get_current_nbSamplePatch() != get_last_nbSamplePatch()) { // number of sampled and populated patches change over time
-            ARRAY::delete_2D<map<ALLELE, map<ALLELE, double> > >(_locusFreq_local[AGE],get_last_nbSamplePatch());
+            ARRAY::delete_2D<map<ALLELE, map<ALLELE, double> > >(_locusFreq_local[AGE],_locusFreq_local_rows[AGE]);
             ARRAY::create_2D<map<ALLELE, map<ALLELE, double> > >(_locusFreq_local[AGE],get_current_nbSamplePatch(), _nb_locus); // [age][sampleID][locus][allele]
+            _locusFreq_local_rows[AGE] = get_current_nbSamplePatch();
         }
         else { // the number of sampled patches has not changed
             for (p = 0; p < get_current_nbSamplePatch(); ++p) {
@@ -1568,11 +1571,12 @@ template<class SH>void StatHandler<SH>::setFstat_Nei_Chesser_perPatchPair(const 
     if (!_fst_matrix) ARRAY::create_1D<double**>(_fst_matrix, NB_AGE_CLASSES, NULL); // first time
     if (!_fst_matrix[AGE]) 	ARRAY::create_2D(_fst_matrix[AGE], get_current_nbSamplePatch(), get_current_nbSamplePatch(), (double)my_NAN);
     else if (get_current_nbSamplePatch() != get_last_nbSamplePatch()) { // number of sampeld patches may change over time
-        ARRAY::delete_2D(_fst_matrix[AGE], get_last_nbSamplePatch());
+        ARRAY::delete_2D(_fst_matrix[AGE], _fst_matrix_rows[AGE]);
         ARRAY::create_2D(_fst_matrix[AGE], get_current_nbSamplePatch(), get_current_nbSamplePatch(), (double)my_NAN);
     }
     else ARRAY::reset_2D(_fst_matrix[AGE], get_current_nbSamplePatch(), get_current_nbSamplePatch(), (double)my_NAN);
-    
+    _fst_matrix_rows[AGE] = get_current_nbSamplePatch();
+
     double * hs_pop = new double[get_current_nbSamplePatch()];
     double * ho_pop = new double[get_current_nbSamplePatch()];
     vector<TPatch*>::iterator curPop1, curPop2, endPop = get_vSamplePatch().end();
@@ -2643,11 +2647,12 @@ StatHandler<SH>::setFstat_Weir_Cockerham_perPatchPair(const age_idx & AGE)
     // first time
     if (!_fst_matrix_wc[AGE]) ARRAY::create_2D(_fst_matrix_wc[AGE], get_current_nbSamplePatch(), get_current_nbSamplePatch(), (double)my_NAN);
     else if (get_current_nbSamplePatch() != get_last_nbSamplePatch()) {
-        ARRAY::delete_2D(_fst_matrix_wc[AGE], get_last_nbSamplePatch());
+        ARRAY::delete_2D(_fst_matrix_wc[AGE], _fst_matrix_wc_rows[AGE]);
         ARRAY::create_2D(_fst_matrix_wc[AGE], get_current_nbSamplePatch(),	get_current_nbSamplePatch(), (double)my_NAN);
     }
     else ARRAY::reset_2D(_fst_matrix_wc[AGE], get_current_nbSamplePatch(), get_current_nbSamplePatch(), (double)my_NAN);
-    
+    _fst_matrix_wc_rows[AGE] = get_current_nbSamplePatch();
+
     unsigned int* pop_sizes = new unsigned int[get_current_nbSamplePatch()];
     map<ALLELE, double> **ho_patch_allele = new map<ALLELE, double> *[get_current_nbSamplePatch()]; // ho_patch_allele[p][l][a]
     unsigned int tot_size, l, i, j, cur_pop_sizes[2];
@@ -3106,11 +3111,15 @@ StatHandler<SH>::setCoaMatrixTheta(const age_idx & AGE)
     
     // create the matrix if not present
     if(!_coa_matrix) ARRAY::create_1D<double**>(_coa_matrix, NB_AGE_CLASSES, NULL); // first time
-    if(!_coa_matrix[AGE]) 	ARRAY::create_2D(_coa_matrix[AGE], get_current_nbSamplePatch(), get_current_nbSamplePatch(), (double)my_NAN);
+    if(!_coa_matrix[AGE]) {
+        ARRAY::create_2D(_coa_matrix[AGE], get_current_nbSamplePatch(), get_current_nbSamplePatch(), (double)my_NAN);
+        _coa_matrix_rows[AGE] = get_current_nbSamplePatch();
+    }
     else if(get_last_nbSamplePatch() != get_current_nbSamplePatch() && !already_computed(_computed[17], AGE)) { // the number of sampled patches may change over time
-        ARRAY::delete_2D(_coa_matrix[AGE], get_last_nbSamplePatch());
+        ARRAY::delete_2D(_coa_matrix[AGE], _coa_matrix_rows[AGE]);
         ARRAY::create_2D(_coa_matrix[AGE], get_current_nbSamplePatch(),
                          get_current_nbSamplePatch(), (double)my_NAN);
+        _coa_matrix_rows[AGE] = get_current_nbSamplePatch();
     }
     else { // reset
         for (i = 0; i < get_current_nbSamplePatch(); ++i) {
@@ -3181,14 +3190,17 @@ template<class SH>void StatHandler<SH>::setCoaMatrixAlpha(const age_idx & AGE) {
     // create the matrix if not present
     if (!_coa_matrix)
         ARRAY::create_1D<double**>(_coa_matrix, NB_AGE_CLASSES, NULL); // first time
-    if (!_coa_matrix[AGE])
+    if (!_coa_matrix[AGE]) {
         ARRAY::create_2D(_coa_matrix[AGE], get_current_nbSamplePatch(),
                          get_current_nbSamplePatch(), (double)my_NAN);
+        _coa_matrix_rows[AGE] = get_current_nbSamplePatch();
+    }
     else if (get_last_nbSamplePatch() != get_current_nbSamplePatch() && !already_computed
              (_computed[16], AGE)) { // the number of sampled patches may change over time
-        ARRAY::delete_2D(_coa_matrix[AGE], get_last_nbSamplePatch());
+        ARRAY::delete_2D(_coa_matrix[AGE], _coa_matrix_rows[AGE]);
         ARRAY::create_2D(_coa_matrix[AGE], get_current_nbSamplePatch(),
                          get_current_nbSamplePatch(), (double)my_NAN);
+        _coa_matrix_rows[AGE] = get_current_nbSamplePatch();
     }
     else { // just reset upper half (without diagonal)
         for (i = 0; i < get_current_nbSamplePatch(); ++i) {

--- a/src/ttquanti.cpp
+++ b/src/ttquanti.cpp
@@ -3496,11 +3496,12 @@ TTQuantiSH::setQst_perPatchPair(const age_idx& AGE)
 {
     if(!_qst_matrix) ARRAY::create_2D(_qst_matrix, get_current_nbSamplePatch(), get_current_nbSamplePatch(), (double)my_NAN);
     else if(get_current_nbSamplePatch()!=get_last_nbSamplePatch()){ // number of sampled patches may change over time
-        ARRAY::delete_2D(_qst_matrix, get_last_nbSamplePatch());
+        ARRAY::delete_2D(_qst_matrix, _qst_matrix_rows);
         ARRAY::create_2D(_qst_matrix, get_current_nbSamplePatch(), get_current_nbSamplePatch(), (double)my_NAN);
     }
     else ARRAY::reset_2D(_qst_matrix, get_current_nbSamplePatch(), get_current_nbSamplePatch(), (double)my_NAN);
-    
+    _qst_matrix_rows = get_current_nbSamplePatch();
+
     setVar_Va(AGE);
     setMeanAndVar_Vp();
     
@@ -3571,11 +3572,12 @@ TTQuantiSH::setQstF_perPatchPair(const age_idx& AGE)
 {
     if(!_qstF_matrix) ARRAY::create_2D(_qstF_matrix, get_current_nbSamplePatch(), get_current_nbSamplePatch(), (double)my_NAN);
     else if(get_current_nbSamplePatch()!=get_last_nbSamplePatch()){ // number of sampled patches may change over time
-        ARRAY::delete_2D(_qstF_matrix, get_current_nbSamplePatch());
+        ARRAY::delete_2D(_qstF_matrix, _qstF_matrix_rows);
         ARRAY::create_2D(_qstF_matrix, get_current_nbSamplePatch(), get_current_nbSamplePatch(), (double)my_NAN);
     }
     else ARRAY::reset_2D(_qstF_matrix, get_current_nbSamplePatch(), get_current_nbSamplePatch(), (double)my_NAN);
-    
+    _qstF_matrix_rows = get_current_nbSamplePatch();
+
     setVar_Va(AGE);
     setMeanAndVar_Vp();
     


### PR DESCRIPTION
## Problem

quantiNemo crashed with SIGSEGV in roughly one run in four, always during process teardown *after* the simulation had completed every generation. Output files were correct whenever it did not fire — a destruction-path fault, not a results fault. A crashed run reached the final generation but never printed `quantiNemo terminated successfully!`.

`~TTQuantiSH()` ended with:

```cpp
assert(_popPtr);
ARRAY::delete_2D(_qst_matrix,  get_current_nbSamplePatch());
ARRAY::delete_2D(_qstF_matrix, get_current_nbSamplePatch());
```

`StatHandlerBase::get_current_nbSamplePatch()` is just `return _popPtr->_current_nbSamplePatch;`, so the destructor dereferenced the metapop to learn how many rows to free. ASan pins down the ordering: the metapop is deleted in `TReplicate::~TReplicate` (treplicate.cpp:95) and the stat handlers are torn down later in the *same* `TSimulation::~TSimulation`, so `_popPtr` dangles.

```
StatHandlerBase::get_current_nbSamplePatch()   <- heap-use-after-free
TTQuantiSH::~TTQuantiSH()
TTraitQuantiProto::~TTraitQuantiProto()
ComponentManager::reset_sim_components()
ComponentManager::~ComponentManager()
TSimulation::~TSimulation()
run_sims_withinThread(...)
```

The `assert(_popPtr)` never helped: it only tests for null rather than validity, and `types.h` defines `NDEBUG` unconditionally for non-`_DEBUG` builds, so it is compiled out of Release entirely.

## Scope is wider than the quanti trait

`StatHandler<SH>::~StatHandler()` had the same pattern for five more matrices, and additionally **stored** through the dangling pointer before freeing:

```cpp
if(!get_current_nbSamplePatch()) _popPtr->_current_nbSamplePatch = get_last_nbSamplePatch();
```

That destructor runs for every stat-handler subclass, so `TTNeutralSH`, `MetapopSH`, `LCE_StatSH`, and `LCE_CoalescenceSH` were all exposed even though none of them declares an unsafe destructor of its own. The surrounding `if(_popPtr)` guard was as ineffective as the assert.

## Fix

Record the row count used at allocation in a member and free with that, so the destructors touch no external object: `_qst_matrix_rows`/`_qstF_matrix_rows` in `TTQuantiSH`, and per-age `_*_rows[NB_AGE_CLASSES]` in `StatHandler`. `~StatHandlerBase` is empty, so the destruction chain is now entirely free of `_popPtr`.

Correcting teardown order was the alternative, but the metapop is destroyed by a sibling of the component manager and that ordering is shared by every trait type, so the local fix is the safer change.

Two latent miscounts in the same lines go away with it — both could free the wrong number of rows whenever the sampled-patch count changed mid-run, even with a valid `_popPtr`:

- `setQstF_perPatchPair()` freed `_qstF_matrix` with the **new** row count instead of the old one, unlike its sibling `setQst_perPatchPair()` which correctly used the old one.
- The `_coa_matrix` sites gate reallocation on `already_computed()`, so the reset branch is reachable with a matrix still at its previous size. The recorded count is therefore set only in the branches that actually allocate, not unconditionally.

## Verification

| | passes | failures |
|---|---|---|
| Baseline @ 51033a3 | 18/20 | 2 × SIGSEGV (rc=139) |
| This branch | **20/20** | 0 |

Both baseline crash reports carry the stack above.

The soak alone is suggestive rather than conclusive — 2/20 is a ~10% observed rate, and at that rate twenty clean runs is only ~88% confidence. The load-bearing evidence is deterministic: under ASan the baseline aborts every time with `heap-use-after-free` at `stathandlerbase.cpp:175`, while this branch runs the identical config clean.

Results are unchanged: one run before and after with a fixed seed, `diff -r -x '*.log'` clean, and matching MD5s on `simulation_mean/stats/var.txt`.

LeakSanitizer is unavailable on macOS, so this was not confirmed leak-free by a counter — ASan still covers the invalid-free and use-after-free that these changes affect.

## Known adjacent issue, not addressed here

The `_coa_matrix` reset branches loop to `get_current_nbSamplePatch()` while indexing a matrix that may still be at its old size — an out-of-bounds write in the same family, but on a live compute path rather than teardown, so it could corrupt results rather than only crash at exit. It needs its own reproducer (a config where the sampled-patch count actually changes mid-run) and is better handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)