### PR TITLE
--emit-json: drop allele_freqs, bump schema_version to 3

### DIFF
--- a/doc/developer_guide.md
+++ b/doc/developer_guide.md
@@ -567,12 +567,18 @@ stdout, so it suits notebooks, pipelines, or any other tooling. It is **inert un
   than silently picking one (checked in `TSimManager::run()` and `TSimulation::ini_stats()`).
 - stdout carries **only JSON**: `verbose_message` and `verbose_warning` are zeroed;
   `error()` still goes to stderr.
-- Output is a **header + frames** stream (`schema_version "2"`), one flushed line each:
+- Output is a **header + frames** stream (`schema_version "3"`), one flushed line each:
   - **one `kind:"header"` record first**, declaring the run's static layout once (patch
     count, the locus table, the quantitative-trait count, which estimators are computed);
   - then **one `kind:"frame"` record per logged generation** (every `stat_log_time`, plus
     always the final generation), carrying only positional numeric payloads read against the
     header — no keys, no repeated identity.
+
+  `schema_version "3"` (decision 12) **removed the per-frame `allele_freqs` payload**
+  (`[locus][patch][allele]` frequency arrays): it dominated stream/storage cost yet had no
+  consumer. Marker/allele-level output is now obtained **only** on explicit export request
+  (`request_full_genotypes` + `export_formats`), carried verbatim in `full_genotypes`. The
+  header locus table (`type` + `n_alleles`) is retained as static run layout.
 
 **How it is driven.** The emitter is a regular `FileHandler` (`EmitJsonFH`) registered with
 the `FileServices`, *not* a hand-placed hook. `LCE_StatServiceNotifier::loadFileServices`
@@ -601,8 +607,7 @@ sequenceDiagram
     FN->>E: update()
     alt cadence or final generation
       E->>E: FHwrite() → header once, then a frame
-      E->>E: count allele freqs from live ADULTS
-      E->>E: read FST, Ho, Hs, Ht, QST from StatHandlers
+      E->>E: read requested scalar stats + phenotype moments from live ADULTS
       E->>OUT: one flushed JSON line
     end
   end
@@ -624,22 +629,24 @@ notifier has refreshed the estimators for that generation.*
 **What the records contain**
 
 ```json
-{"schema_version":"2","kind":"header","replicate":1,"patches":2,
+{"schema_version":"3","kind":"header","replicate":1,"patches":2,
  "loci":[{"type":"ntrl","n_alleles":3},{"type":"quanti","n_alleles":255}],
  "traits":1,"stats":["fst","qst","ho","hs","ht"]}
-{"schema_version":"2","kind":"frame","generation":3,
- "allele_freqs":[[[0.4,0.3,0.3],[0.5,0.2,0.3]], ...],
+{"schema_version":"3","kind":"frame","generation":3,
  "phenotype":[[[0.23,5.58],[0.83,7.22]]],
  "stats":[0.094,null,0.125,0.63,0.66]}
 ```
 
-- **header.loci** is the locus table in canonical order (ntrl loci first, then quanti); each
-  entry's `n_alleles` is the (ragged) inner length of that locus's `allele_freqs`.
+- **header.loci** is the locus table in canonical order (ntrl loci first, then quanti);
+  `n_alleles` is retained as static locus metadata (it was the ragged inner length of the
+  removed frame `allele_freqs`) and is the locus ordering referenced by genotype exports.
 - **header.stats** lists which layer-1 estimators this run computes, in a fixed order; the
   frame's `stats` array is positionally aligned to it (so a not-computed stat is simply
   absent from both).
-- **frame.allele_freqs** is `[locus][patch][allele]`, counted directly from the live ADULT
-  population, independent of the stat handler's internal tables.
+- **frame `allele_freqs` was REMOVED in `schema_version "3"`** (decision 12). It was the
+  dominant stream/storage cost yet had no consumer; marker/allele-level output is now
+  export-only (`request_full_genotypes` + `export_formats` → a verbatim `full_genotypes`
+  file). Frames now carry only `phenotype` and `stats`.
 - **frame.stats** are the *real* layer-1 estimators (§8). A value the engine cannot reach is
   emitted as JSON `null` (via `ej_put_num_or_null`), never a fake number — the `my_NAN`
   sentinel and non-finite values both map to `null`.

--- a/include/emit_json.h
+++ b/include/emit_json.h
@@ -12,7 +12,8 @@
  *   trait count, and which layer-1 estimators are computed) — followed by ONE
  *   compact `kind:"frame"` record per logged generation (every stat_log_time,
  *   plus the final generation) carrying only positional numeric payloads
- *   (allele_freqs, phenotype, stats) read against the header.
+ *   (phenotype, stats) read against the header. schema_version "3" (decision 12)
+ *   dropped the per-frame allele_freqs payload; marker data is export-only.
  *
  *   This file is part of quantiNemo and is distributed under the GNU General
  *   Public License v3 (or later), like the rest of the program.

--- a/include/emit_json.h
+++ b/include/emit_json.h
@@ -12,8 +12,7 @@
  *   trait count, and which layer-1 estimators are computed) — followed by ONE
  *   compact `kind:"frame"` record per logged generation (every stat_log_time,
  *   plus the final generation) carrying only positional numeric payloads
- *   (phenotype, stats) read against the header. schema_version "3" (decision 12)
- *   dropped the per-frame allele_freqs payload; marker data is export-only.
+ *   (phenotype, stats) read against the header.
  *
  *   This file is part of quantiNemo and is distributed under the GNU General
  *   Public License v3 (or later), like the rest of the program.

--- a/src/emit_json_record.inc
+++ b/src/emit_json_record.inc
@@ -17,12 +17,6 @@
  *       header. No keys, no repeated identity.
  *   A reader must consume the header before it can interpret any frame.
  *
- *   schema_version 3 (decision 12) REMOVED the per-frame allele_freqs payload
- *   [locus][patch][allele]: it dominated stream/storage cost yet had no consumer.
- *   Marker/allele-level output is now export-only (request_full_genotypes +
- *   export_formats -> a verbatim FSTAT/Arlequin/PLINK/NEXUS file). The header
- *   locus table (type + n_alleles) is retained as static run layout.
- *
  *   STATS (the metapop-wide scalar layer-1 estimators) are NO LONGER a hardcoded
  *   five. We enumerate the stat recorders the run actually requested (parsed from
  *   the .ini `stat` tokens into StatRecorder objects) and, for each that is a
@@ -225,8 +219,7 @@ void ej_emit_header(TMetapop* pop)
         << ",\"patches\":" << pop->get_nbPatch();
 
     // loci: ntrl first then quanti; each declares its (declared) allele count.
-    // Retained as static locus layout (schema_version 3 dropped frame allele_freqs
-    // but keeps this table); it is the locus ordering referenced by genotype exports.
+    // This is the locus ordering referenced by genotype exports.
     rec << ",\"loci\":[";
     {
         bool first = true;
@@ -277,12 +270,6 @@ void ej_emit_frame(TMetapop* pop)
     std::ostringstream rec;
     rec << "{\"schema_version\":\"3\",\"kind\":\"frame\",\"generation\":"
         << pop->getCurrentGeneration();
-
-    // NOTE (schema_version 3, decision 12): the per-frame allele_freqs payload
-    // [locus][patch][allele] was REMOVED. It dominated stream/storage cost yet had
-    // no consumer; marker/allele-level output is now export-only (request_full_
-    // genotypes + export_formats -> a verbatim FSTAT/Arlequin/PLINK/NEXUS file in
-    // full_genotypes). Frames now carry only phenotype moments and scalar stats.
 
     // ---- phenotype[trait][patch][mean,var] (omitted when no quanti traits) ----
     {

--- a/src/emit_json_record.inc
+++ b/src/emit_json_record.inc
@@ -7,15 +7,21 @@
  *   pulls in. That guarantees the concrete TTNeutralSH / TTQuantiSH / MetapopSH
  *   instantiations are visible.
  *
- *   Output is a HEADER + FRAMES stream (schema_version 2):
+ *   Output is a HEADER + FRAMES stream (schema_version 3):
  *     - ONE `kind:"header"` record is emitted first, declaring the static layout
  *       of the run (patch count, the locus table in canonical order with the
  *       per-locus allele counts, the trait count, and which layer-1 estimators
  *       this run computes).
  *     - then ONE compact `kind:"frame"` record per logged generation, carrying
- *       only positional numeric payloads (allele_freqs, phenotype, stats) read
- *       against the header. No keys, no repeated identity.
+ *       only positional numeric payloads (phenotype, stats) read against the
+ *       header. No keys, no repeated identity.
  *   A reader must consume the header before it can interpret any frame.
+ *
+ *   schema_version 3 (decision 12) REMOVED the per-frame allele_freqs payload
+ *   [locus][patch][allele]: it dominated stream/storage cost yet had no consumer.
+ *   Marker/allele-level output is now export-only (request_full_genotypes +
+ *   export_formats -> a verbatim FSTAT/Arlequin/PLINK/NEXUS file). The header
+ *   locus table (type + n_alleles) is retained as static run layout.
  *
  *   STATS (the metapop-wide scalar layer-1 estimators) are NO LONGER a hardcoded
  *   five. We enumerate the stat recorders the run actually requested (parsed from
@@ -214,12 +220,13 @@ std::vector<EjScalarStat> ej_collect_scalar_stats(TMetapop* pop)
 void ej_emit_header(TMetapop* pop)
 {
     std::ostringstream rec;
-    rec << "{\"schema_version\":\"2\",\"kind\":\"header\""
+    rec << "{\"schema_version\":\"3\",\"kind\":\"header\""
         << ",\"replicate\":1"
         << ",\"patches\":" << pop->get_nbPatch();
 
-    // loci: ntrl first then quanti; each declares its (declared) allele count,
-    // which is the RAGGED inner length of that locus's frame allele_freqs.
+    // loci: ntrl first then quanti; each declares its (declared) allele count.
+    // Retained as static locus layout (schema_version 3 dropped frame allele_freqs
+    // but keeps this table); it is the locus ordering referenced by genotype exports.
     rec << ",\"loci\":[";
     {
         bool first = true;
@@ -268,61 +275,14 @@ void ej_emit_frame(TMetapop* pop)
     unsigned int nbProto = pop->getTraitPrototypeSize();
 
     std::ostringstream rec;
-    rec << "{\"schema_version\":\"2\",\"kind\":\"frame\",\"generation\":"
+    rec << "{\"schema_version\":\"3\",\"kind\":\"frame\",\"generation\":"
         << pop->getCurrentGeneration();
 
-    // ---- allele_freqs[locus][patch][allele] (ntrl loci first, then quanti) ----
-    rec << ",\"allele_freqs\":[";
-    {
-        bool firstLocus = true;
-        for (int pass = 0; pass < 2; ++pass) {
-            for (unsigned int t = 0; t < nbProto; ++t) {
-                TTraitProto& proto = pop->getTraitPrototype(t);
-                if (proto.get_type() != EJ_LOCUS_ORDER[pass]) continue;
-                unsigned int absIdx  = proto.get_absolute_index();
-                unsigned int nbLocus = proto.get_nb_locus();
-
-                for (unsigned int l = 0; l < nbLocus; ++l) {
-                    unsigned int nAll = proto.get_nb_allele(l);
-                    if (!firstLocus) rec << ",";
-                    firstLocus = false;
-
-                    rec << "[";                      // patch axis
-                    for (unsigned int p = 0; p < nbPatch; ++p) {
-                        TPatch* patch = pop->get_vPatch(p);
-                        std::vector<unsigned int> counts(nAll, 0);
-                        unsigned int total = 0;
-
-                        for (int s = 0; s < 2; ++s) {
-                            sex_t SEX = SEXES[s];
-                            unsigned int n = patch->size(SEX, AGE);
-                            for (unsigned int i = 0; i < n; ++i) {
-                                TIndividual* ind = patch->get(SEX, AGE, i);
-                                if (!ind) continue;
-                                TTrait* seq = ind->getTrait((int)absIdx);
-                                if (!seq) continue;
-                                for (unsigned int c = 0; c < ploidy; ++c) {
-                                    ALLELE a = seq->allele(l, c);
-                                    if ((unsigned int)a < nAll) { counts[a]++; ++total; }
-                                }
-                            }
-                        }
-
-                        if (p) rec << ",";
-                        rec << "[";                  // allele axis (length nAll)
-                        for (unsigned int a = 0; a < nAll; ++a) {
-                            if (a) rec << ",";
-                            double f = (total > 0) ? (double)counts[a] / (double)total : 0.0;
-                            ej_put_num(rec, f);
-                        }
-                        rec << "]";
-                    }
-                    rec << "]";
-                }
-            }
-        }
-    }
-    rec << "]";
+    // NOTE (schema_version 3, decision 12): the per-frame allele_freqs payload
+    // [locus][patch][allele] was REMOVED. It dominated stream/storage cost yet had
+    // no consumer; marker/allele-level output is now export-only (request_full_
+    // genotypes + export_formats -> a verbatim FSTAT/Arlequin/PLINK/NEXUS file in
+    // full_genotypes). Frames now carry only phenotype moments and scalar stats.
 
     // ---- phenotype[trait][patch][mean,var] (omitted when no quanti traits) ----
     {


### PR DESCRIPTION
## Summary
- Drops the per-frame `allele_freqs` payload (`[locus][patch][allele]` frequency arrays) from `--emit-json` output. It dominated stream/storage size (grows as replicates × logged_generations × loci × patches × alleles) and has no consumer downstream — nothing plots or aggregates it. Allele/genotype-level output stays available exclusively via the existing export path (`request_full_genotypes` + `export_formats` → a verbatim FSTAT/Arlequin/PLINK/NEXUS file), which was already never parsed into JSON.
- Bumps `schema_version` `"2"` → `"3"` in both header and frame records — breaking, since the schema is `additionalProperties:false`. This is the engine-side follow-up to decision 12 in the [quantinemo-frontend](https://github.com/frederic-michaud/quantinemo-frontend) contracts (branch `contracts/remove-allele-freqs-v3`).

## Note on an earlier revision of this PR
An earlier push of this branch also carried a `-fno-strict-aliasing` Makefile change, based on an initial diagnosis of a `-O3` segfault attributed to strict-aliasing UB in the genome-storage refactor (`161c4eb`). That diagnosis did not hold up: a clean rebuild (no stale `.o` files) at `161c4eb`, with or without this PR's change, ran 160+ iterations across all 4 engine test configs with zero crashes, and no `reinterpret_cast`/union/type-punning was found in the relevant code (`AlleleContainer` in `include/types.h` is a plain `ALLELE*` buffer accessed only through `ALLELE&`). The likely explanation for the original crash is stale `.o` files linked across the submodule bump (an ODR/ABI mismatch, not aliasing UB) rather than anything in this diff. The Makefile change has been removed from this PR.

## Test plan
- [x] `make release` builds cleanly on top of current `master`.
- [x] Ran the real binary under `--emit-json` on all 4 existing engine test configs (`tests/single_run_{ntrl,quanti,multi_stat,legacy5}.ini`) through `tests/validate_stream.py` against the v3 schema: 0 schema errors, every line declares `schema_version "3"`, zero `allele_freqs` occurrences, `phenotype`/`stats` payloads unchanged.
- [x] Re-verified with a clean rebuild (no stale `.o`): 0 crashes across 160+ runs of all 4 configs, with and without this diff.
- [ ] Downstream: quantinemo-frontend's `contracts/remove-allele-freqs-v3` branch + this engine bump still need to land together (the frontend's stub engine already speaks v3; only the real binary was on v2).