### PR TITLE
--emit-json: emit full_genotypes (FSTAT/Arlequin/PLINK) on the final frame

### DIFF
--- a/include/filehandler.h
+++ b/include/filehandler.h
@@ -81,7 +81,18 @@ protected:
     void write_Plink_pheno (const age_idx& cur_age, const sex_t& cur_sex, ostream& FILE,
                           TPatch* current_patch, const int& nbPatchDigit, const int& position,
                           char sep);
-    
+
+    // --- emit-json single-run streaming: render the genotype export to an
+    //     arbitrary ostream (an in-memory ostringstream) instead of a disk file.
+    //     The disk-writing write_Fstat/write_Arlequin(bool) wrappers now delegate
+    //     their content to these body functions, so on-disk and streamed output
+    //     are produced by the SAME code path. write_Plink_body combines PLINK's
+    //     natively-separate .map/.ped(/.pheno) files into one delimited payload.
+    void write_Fstat_body    (ostream& FILE, bool extended);
+    void write_Arlequin_body (ostream& FILE, bool extended);
+    void write_Plink_body    (ostream& FILE, bool extended);
+    void write_Plink_map_body(ostream& FILE, sex_t SEX, bool extended);
+
 protected:
     string _script;       // a script name which should be executed after the write of a file
     vector<TTraitProto*> _trait;
@@ -201,6 +212,15 @@ public:
         }
     }
     
+    /** emit-json single-run streaming entry point: render the requested genotype
+     *  export (all attached traits, in attach order — the caller attaches ntrl
+     *  loci first, then quanti, matching the stream contract's canonical locus
+     *  ordering) to `out` as one in-memory payload. `choice` is the 1..6 selector
+     *  used by ntrl_save_genotype/quanti_save_genotype (1/2 FSTAT, 3/4 Arlequin,
+     *  5/6 PLINK; even values = the "extended" variant). Returns false for an
+     *  unknown choice. The handler must already have its traits, age and sex set. */
+    bool write_genotype_to_stream(ostream& out, unsigned int choice);
+
     /**Default behaviour of the class, called by Handler::update().**/
     virtual void  FHwrite();
     void (FileHandler::*writeGenotype_func_ptr)(bool);

--- a/src/emit_json_record.inc
+++ b/src/emit_json_record.inc
@@ -45,7 +45,10 @@
 #include <utility>
 #include <vector>
 
+#include <cstdio>
+
 #include "emit_json.h"
+#include "filehandler.h"
 #include "patch.h"
 #include "stat_rec_base.h"
 #include "stathandlerbase.h"
@@ -68,6 +71,35 @@ void ej_put_num_or_null(std::ostream& os, double v)
     os << tmp.str();
 }
 
+// Write `s` as a JSON string literal (quotes + escaping). REQUIRED for the
+// verbatim genotype payload: FSTAT/Arlequin/PLINK text is full of newlines, and
+// Arlequin embeds double-quotes (SampleName="pop_1"), so it must be escaped.
+void ej_put_json_string(std::ostream& os, const std::string& s)
+{
+    os << '"';
+    for (std::string::size_type i = 0; i < s.size(); ++i) {
+        unsigned char c = (unsigned char)s[i];
+        switch (c) {
+            case '"':  os << "\\\""; break;
+            case '\\': os << "\\\\"; break;
+            case '\n': os << "\\n";  break;
+            case '\r': os << "\\r";  break;
+            case '\t': os << "\\t";  break;
+            case '\b': os << "\\b";  break;
+            case '\f': os << "\\f";  break;
+            default:
+                if (c < 0x20) {                 // other control chars -> \u00XX
+                    char buf[8];
+                    std::snprintf(buf, sizeof buf, "\\u%04x", (unsigned int)c);
+                    os << buf;
+                } else {
+                    os << (char)c;
+                }
+        }
+    }
+    os << '"';
+}
+
 void ej_put_num(std::ostream& os, double v)
 {
     std::ostringstream tmp;
@@ -85,6 +117,79 @@ unsigned int ej_count_quanti_traits(TMetapop* pop)
     for (unsigned int t = 0; t < nbProto; ++t)
         if (pop->getTraitPrototype(t).get_type() == "quanti") ++n;
     return n;
+}
+
+// --------------------------------------------------------------------------- //
+// GENOTYPE EXPORT (full_genotypes)
+//
+// A run requests a genotype export via ntrl_save_genotype / quanti_save_genotype
+// (the .ini params build_ini emits for SimParams.export_format; decision 14).
+// Both are set to the SAME choice — 1 FSTAT, 3 Arlequin, 5 PLINK (the
+// non-"extended" variants) — for every trait type that actually has loci.
+//
+// ntrl/quanti MERGE POLICY (the open question decision 14 left to engine-cpp):
+// the two writers are historically SEPARATE per-trait-type FileHandlers producing
+// SEPARATE files, but the stream contract wants ONE combined payload ordered
+// "all neutral loci first, then all quanti loci". We resolve this WITHOUT merging
+// two files: the FSTAT/Arlequin/PLINK writers iterate _trait[] GENERICALLY over
+// all loci regardless of type, so we attach BOTH trait types to a SINGLE
+// FileHandler (neutral protos first, then quanti — the contract's canonical
+// order) and invoke the writer ONCE. That yields one well-formed file whose loci
+// span ntrl-then-quanti, exactly matching header.loci. A one-type-only run
+// (neutral-only or quanti-only) is just the degenerate case with one type
+// attached. See filehandler.cpp write_genotype_to_stream / write_Plink_body.
+// --------------------------------------------------------------------------- //
+
+// The genotype-export format choice (1..6) requested for this run, or 0 if none.
+// build_ini sets ntrl_save_genotype on neutral protos and quanti_save_genotype on
+// quanti protos to the same value; we read whichever matching param is non-zero.
+unsigned int ej_genotype_choice(TMetapop* pop)
+{
+    unsigned int nbProto = pop->getTraitPrototypeSize();
+    for (unsigned int t = 0; t < nbProto; ++t) {
+        TTraitProto& proto = pop->getTraitPrototype(t);
+        unsigned int c = 0;
+        if (proto.get_type() == "ntrl")
+            c = (unsigned int)proto.get_parameter_value("ntrl_save_genotype");
+        else if (proto.get_type() == "quanti")
+            c = (unsigned int)proto.get_parameter_value("quanti_save_genotype");
+        if (c) return c;
+    }
+    return 0;
+}
+
+// The stream/contract format name for a 1..6 choice, or NULL if not a genotype
+// export choice.
+const char* ej_genotype_format_name(unsigned int choice)
+{
+    switch (choice) {
+        case 1: case 2: return "FSTAT";
+        case 3: case 4: return "Arlequin";
+        case 5: case 6: return "PLINK";
+        default:        return 0;
+    }
+}
+
+// Render the combined genotype export (ntrl loci first, then quanti) to a string.
+std::string ej_render_genotypes(TMetapop* pop, unsigned int choice)
+{
+    FileHandler fh;
+    fh.set_age(0);      // adults (matches build_ini's *_genot_age 0 and the emitter)
+    fh.set_sex(0);      // both sexes (matches build_ini's *_genot_sex 0)
+
+    // attach ntrl trait protos first, then quanti — the contract's locus order.
+    unsigned int nbProto = pop->getTraitPrototypeSize();
+    for (int pass = 0; pass < 2; ++pass) {
+        for (unsigned int t = 0; t < nbProto; ++t) {
+            TTraitProto& proto = pop->getTraitPrototype(t);
+            if (proto.get_type() != EJ_LOCUS_ORDER[pass]) continue;
+            fh.set(&proto);
+        }
+    }
+
+    std::ostringstream out;
+    fh.write_genotype_to_stream(out, choice);
+    return out.str();
 }
 
 // --------------------------------------------------------------------------- //
@@ -254,6 +359,18 @@ void ej_emit_header(TMetapop* pop)
     }
     rec << "]";
 
+    // genotypes: declared ONCE here iff the run requested a genotype export. The
+    // payload itself rides on the frame for the final generation only (see
+    // ej_emit_frame). generation = the final generation (build_ini sets
+    // *_genot_logtime = generations, so the writer fires there, and the emitter
+    // always emits a frame on the final generation).
+    unsigned int gchoice = ej_genotype_choice(pop);
+    const char* gfmt = gchoice ? ej_genotype_format_name(gchoice) : 0;
+    if (gfmt) {
+        rec << ",\"genotypes\":{\"format\":\"" << gfmt
+            << "\",\"generation\":" << pop->getGenerations() << "}";
+    }
+
     rec << "}";
     std::cout << rec.str() << "\n" << std::flush;
 }
@@ -327,6 +444,22 @@ void ej_emit_frame(TMetapop* pop)
                 ej_put_num_or_null(rec, v);
             }
             rec << "]";
+        }
+    }
+
+    // ---- full_genotypes: ONLY on the final generation, only when requested ----
+    // header.genotypes.generation == getGenerations(); the emitter always emits a
+    // frame on the final generation (LCE_StatServiceNotifier forces it), so this
+    // fires exactly once. The captured export text is embedded VERBATIM as a
+    // JSON-escaped string; pyquantinemo relays it byte-for-byte to the download.
+    {
+        unsigned int gchoice = ej_genotype_choice(pop);
+        const char* gfmt = gchoice ? ej_genotype_format_name(gchoice) : 0;
+        if (gfmt && pop->getCurrentGeneration() == pop->getGenerations()) {
+            std::string data = ej_render_genotypes(pop, gchoice);
+            rec << ",\"full_genotypes\":{\"format\":\"" << gfmt << "\",\"data\":";
+            ej_put_json_string(rec, data);
+            rec << "}";
         }
     }
 

--- a/src/filehandler.cpp
+++ b/src/filehandler.cpp
@@ -167,20 +167,9 @@ void FileHandler::FHwrite()
 /** Writes genotype in a FSTAT-like format, the age class and the sex are added after the pop id.*/
 void FileHandler::write_Fstat(bool extened)
 {
-    unsigned int t, l;
-    
     // get the number of occupied patches
     if (!_popPtr->get_nbSamplePatch()) return; // if no patches are sampled
-    
-    // get the number of digits to visualize
-    unsigned int max_allele = 0; // find the max number of alleles across all traits
-    for (t = 0; t < _nb_trait; ++t) {
-        for (l = 0; l < _trait[t]->get_nb_locus(); ++l) {
-            if (max_allele < _trait[t]->get_nb_allele(l))
-                max_allele = _trait[t]->get_nb_allele(l);
-        }
-    }
-    
+
     // open the file
     string filename = get_path() + getGenerationReplicateFileName()
     + get_extension();
@@ -190,7 +179,34 @@ void FileHandler::write_Fstat(bool extened)
     ofstream FILE(filename.c_str(), ios::out);
     if (!FILE)
         error("Could not open FSTAT output file '%s'!\n", filename.c_str());
-    
+
+    write_Fstat_body(FILE, extened);
+
+    FILE.close();
+
+    // call an external program and pass the name of this file
+    if (!_script.empty()) execute_script(_script, filename);
+}
+
+// ----------------------------------------------------------------------------------------
+// write_Fstat_body
+// ----------------------------------------------------------------------------------------
+/** Renders the FSTAT genotype content to an arbitrary stream (a disk file for the
+ *  classic writer, an ostringstream for --emit-json). Content is byte-for-byte
+ *  identical to the pre-refactor writer for a single-trait-type handler. */
+void FileHandler::write_Fstat_body(ostream& FILE, bool extened)
+{
+    unsigned int t, l;
+
+    // get the number of digits to visualize
+    unsigned int max_allele = 0; // find the max number of alleles across all traits
+    for (t = 0; t < _nb_trait; ++t) {
+        for (l = 0; l < _trait[t]->get_nb_locus(); ++l) {
+            if (max_allele < _trait[t]->get_nb_allele(l))
+                max_allele = _trait[t]->get_nb_allele(l);
+        }
+    }
+
     // write the heading line
     unsigned int position = getNbDigits(max_allele);
     unsigned int tot_nb_loci = 0;
@@ -201,15 +217,18 @@ void FileHandler::write_Fstat(bool extened)
     + 1;
     FILE << maxID << " " << tot_nb_loci << " " << max_allele << " " << position
     << "\n";
-    
-    // write the names of the loci
-    string type = _trait[0]->_type;
+
+    // write the names of the loci. Use EACH trait's own type letter (n/q) so a
+    // combined ntrl+quanti export (the --emit-json single-payload case) labels
+    // every locus by its real type. For a single-type handler this is identical
+    // to the original `_trait[0]->_type` behaviour.
     for (t = 0; t < _nb_trait; ++t) {
+        string type = _trait[t]->_type;
         for (l = 0; l < _trait[t]->get_nb_locus(); ++l) {
             FILE << type[0] << (t + 1) << "_l" << (l + 1) << "\n";
         }
     }
-    
+
     // write all individuals of all patches
     unsigned int nbPatchDigits = getNbDigits(maxID);
     unsigned int a, mask;
@@ -227,11 +246,6 @@ void FileHandler::write_Fstat(bool extened)
             }
         }
     }
-    
-    FILE.close();
-    
-    // call an external program and pass the name of this file
-    if (!_script.empty()) execute_script(_script, filename);
 }
 
 // ----------------------------------------------------------------------------------------
@@ -292,20 +306,9 @@ void FileHandler::write_individual_info_to_stream(ostream& FILE,
 /** Writes genotype in a Areqluin format, the age class and the sex are added after the pop id.*/
 void FileHandler::write_Arlequin(bool extened)
 {
-    unsigned int t, l;
-    
     // get the number of occupied patches
     if (!_popPtr->get_nbSamplePatch()) return; // if no patches are sampled
-    
-    // get the number of digits to visualize
-    unsigned int max_allele = 0; // find the max number of alleles across all traits
-    for (t = 0; t < _nb_trait; ++t) {
-        for (l = 0; l < _trait[t]->get_nb_locus(); ++l) {
-            if (max_allele < _trait[t]->get_nb_allele(l))
-                max_allele = _trait[t]->get_nb_allele(l);
-        }
-    }
-    
+
     // open the file
     string filename = get_path() + getGenerationReplicateFileName() + ".arp";
 #ifdef _DEBUG
@@ -314,7 +317,33 @@ void FileHandler::write_Arlequin(bool extened)
     ofstream FILE(filename.c_str(), ios::out);
     if (!FILE)
         error("Could not open Arlequin output file '%s'!\n", filename.c_str());
-    
+
+    write_Arlequin_body(FILE, extened);
+
+    FILE.close();
+
+    // call an external program and pass the name of this file
+    if (!_script.empty()) execute_script(_script, filename);
+}
+
+// ----------------------------------------------------------------------------------------
+// write_Arlequin_body
+// ----------------------------------------------------------------------------------------
+/** Renders the Arlequin genotype content to an arbitrary stream (a disk file for
+ *  the classic writer, an ostringstream for --emit-json). */
+void FileHandler::write_Arlequin_body(ostream& FILE, bool extened)
+{
+    unsigned int t, l;
+
+    // get the number of digits to visualize
+    unsigned int max_allele = 0; // find the max number of alleles across all traits
+    for (t = 0; t < _nb_trait; ++t) {
+        for (l = 0; l < _trait[t]->get_nb_locus(); ++l) {
+            if (max_allele < _trait[t]->get_nb_allele(l))
+                max_allele = _trait[t]->get_nb_allele(l);
+        }
+    }
+
     char curTime[20];
     time_t tt = time(NULL);
     strftime(curTime, 20, "%d-%m-%Y %H:%M:%S", localtime(&tt));
@@ -369,10 +398,6 @@ void FileHandler::write_Arlequin(bool extened)
         
         FILE << "\n    }\n";
     }
-    FILE.close();
-    
-    // call an external program and pass the name of this file
-    if (!_script.empty()) execute_script(_script, filename);
 }
 
 // ----------------------------------------------------------------------------------------
@@ -704,23 +729,39 @@ void FileHandler::write_Plink_map(string filename, sex_t SEX, bool extended)
     strftime(curTime, 20, "%d-%m-%Y %H:%M:%S", localtime(&tt));
     FILE << "# file created at " << curTime;
     if(extended) FILE << " (listing also multi-allele loci)";
-    
+
+    write_Plink_map_body(FILE, SEX, extended);
+
+    FILE.close();
+
+    // call an external program and pass the name of this file
+    if (!_script.empty()) execute_script(_script, filename);
+}
+
+// ----------------------------------------------------------------------------------------
+// write_Plink_map_body
+// ----------------------------------------------------------------------------------------
+/** Writes the PLINK .map locus records (one per SNP, or per locus when extended)
+ *  to an arbitrary stream. Factored out of write_Plink_map so the --emit-json
+ *  path can render the map into the combined in-memory PLINK payload. */
+void FileHandler::write_Plink_map_body(ostream& FILE, sex_t SEX, bool extended)
+{
     unsigned int t, l, nb_locus;
     char sep= ' ';
     TLocus* curLocus;
-    
+
     // get the max conromosome index (to be able to correctly label the unlinked loci
     TGenomeProto* pGenome = _popPtr->get_protoGenome();
     unsigned int unlinkedChrom = 0;
     if(pGenome->get_nb_locus_linked()) unlinkedChrom = pGenome->get_locus_tot(pGenome->get_nb_locus_linked()-1).get_chromosomePosition()+1;
-    
+
     for (t = 0; t < _nb_trait; ++t) { // for multiple instanciations of a trait
         nb_locus = _trait[t]->get_nb_locus();
-        
+
         for (l = 0; l < nb_locus; ++l) {
             curLocus = &_trait[t]->get_aLocus()[l];
             if(curLocus->get_nb_allele() != 2 && !extended) continue; // not a SNP
-            
+
             if(curLocus->get_chromosomePosition()==my_NAN){ // unlinked locus
                 FILE << "\n" << ++unlinkedChrom
                 << sep << curLocus->get_locus_id_tot()+1
@@ -736,11 +777,88 @@ void FileHandler::write_Plink_map(string filename, sex_t SEX, bool extended)
         }
     }
     FILE << "\n";
-    
-    FILE.close();
-    
-    // call an external program and pass the name of this file
-    if (!_script.empty()) execute_script(_script, filename);
+}
+
+// ----------------------------------------------------------------------------------------
+// write_Plink_body
+// ----------------------------------------------------------------------------------------
+/** Renders a PLINK export as ONE in-memory payload for --emit-json.
+ *
+ *  PLINK is natively a MULTI-FILE format (.map + .ped, plus a .pheno for quanti
+ *  traits), but the streaming contract's `full_genotypes.data` is a single
+ *  verbatim string. We therefore concatenate the sections into one payload with
+ *  explicit `####`-prefixed banner lines (PLINK/quantiNemo already emit
+ *  `#`-comment lines, so these are inert to a lenient reader and let a consumer
+ *  split the payload back into the individual files). Sex-specific recombination
+ *  maps are collapsed to the female map here (the common non-sex-specific case is
+ *  unaffected). This combined-payload shape is an engine-cpp decision for M2; see
+ *  the report / emit_json_record.inc for the rationale. */
+void FileHandler::write_Plink_body(ostream& FILE, bool extended)
+{
+    if (!_popPtr->get_nbSamplePatch()) return;
+    char sep = ' ';
+
+    // ---- .map section ----
+    FILE << "#### PLINK .map ####";
+    write_Plink_map_body(FILE, FEM, extended);
+
+    // ---- .ped section ----
+    FILE << "#### PLINK .ped ####\n";
+    unsigned int maxID = (*_popPtr->get_vSamplePatch().rbegin())->get_ID() + 1;
+    unsigned int nbPatchDigits = getNbDigits(maxID);
+    unsigned int a, mask;
+    vector<TPatch*>::iterator curPop, endPop = _popPtr->get_vSamplePatch().end();
+    for (curPop = _popPtr->get_vSamplePatch().begin(); curPop != endPop; ++curPop) {
+        for (a = 0, mask = 1; a < NB_AGE_CLASSES; ++a, mask <<= 1) {
+            if (mask & _age) {
+                // append=false: single-generation dump, no cross-generation parents.
+                if (_sex != 2)
+                    write_Plink_ped(static_cast<age_idx>(a), FEM, FILE, *curPop,
+                                    nbPatchDigits, 1, sep, extended, false);
+                if (_sex != 1)
+                    write_Plink_ped(static_cast<age_idx>(a), MAL, FILE, *curPop,
+                                    nbPatchDigits, 1, sep, extended, false);
+            }
+        }
+    }
+
+    // ---- .pheno section (only when quantitative traits are present) ----
+    _quantiTraitIndexes = _popPtr->getTraitIndex("quanti");
+    if (!_quantiTraitIndexes.empty()) {
+        FILE << "#### PLINK .pheno ####\n";
+        for (curPop = _popPtr->get_vSamplePatch().begin(); curPop != endPop; ++curPop) {
+            for (a = 0, mask = 1; a < NB_AGE_CLASSES; ++a, mask <<= 1) {
+                if (mask & _age) {
+                    if (_sex != 2)
+                        write_Plink_pheno(static_cast<age_idx>(a), FEM, FILE, *curPop,
+                                          nbPatchDigits, 1, sep);
+                    if (_sex != 1)
+                        write_Plink_pheno(static_cast<age_idx>(a), MAL, FILE, *curPop,
+                                          nbPatchDigits, 1, sep);
+                }
+            }
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------------------
+// write_genotype_to_stream
+// ----------------------------------------------------------------------------------------
+/** emit-json single-run streaming entry point. Samples the current generation
+ *  (adults, per _age) and renders the requested export format to `out`. */
+bool FileHandler::write_genotype_to_stream(ostream& out, unsigned int choice)
+{
+    _popPtr->set_sampledInds(_age);      // update the sampling (as FHwrite does)
+
+    switch (choice) {
+        case 1: write_Fstat_body   (out, false); return true;  // FSTAT
+        case 2: write_Fstat_body   (out, true ); return true;  // FSTAT extended
+        case 3: write_Arlequin_body(out, false); return true;  // Arlequin
+        case 4: write_Arlequin_body(out, true ); return true;  // Arlequin extended
+        case 5: write_Plink_body   (out, false); return true;  // PLINK
+        case 6: write_Plink_body   (out, true ); return true;  // PLINK extended
+        default: return false;
+    }
 }
 
 // ----------------------------------------------------------------------------------------


### PR DESCRIPTION
## What

Extends the single-run `--emit-json` streaming mode to emit a genotype export inline in the JSON stream when the `.ini` requests one (via the existing `ntrl_save_genotype` / `quanti_save_genotype` params). On the **final logged generation only**, the frame carries a `full_genotypes` payload holding the verbatim FSTAT / Arlequin / PLINK file text (JSON-escaped); the header declares `genotypes: {format, generation}` once. This is what lets the quantiNemo Web layer offer working genotype downloads without re-parsing anything — the text is relayed byte-for-byte.

Nothing changes for normal (non-`--emit-json`) runs.

## How

- Factored the existing disk writers (`write_Fstat` / `write_Arlequin` / `write_Plink_ped` / `write_Plink_map`) into stream-taking bodies so their output can be captured into an in-memory string instead of only an `ofstream` to disk. The legacy disk-writing path is preserved (both paths now share the same body code).
- Added `write_genotype_to_stream` + a `full_genotypes` renderer and a JSON-string escaper in `emit_json_record.inc`.
- **Neutral + quantitative loci in one file:** rather than merging two separate writer outputs, both trait prototypes attach to a **single** `FileHandler` (neutral first, then quanti — the canonical locus order the emit-json header declares), and the writer runs once. A neutral-only or quanti-only run is the degenerate single-type case.

## Testing

- `make release` builds clean.
- FSTAT, Arlequin, and PLINK streams validate against the emit-json record schema (0 errors); the existing `--emit-json` fixtures still validate (no regression).
- Combined ntrl+quanti runs produce one coherent file with loci in ntrl-then-quanti order; Arlequin's embedded quotes and all newlines are correctly JSON-escaped.

## Notes for review

- The captured text was **not** validated against external/official FSTAT/Arlequin/PLINK parsers — it reuses the engine's own long-standing writer logic unchanged (only the output stream is redirected), so the streamed bytes equal what the engine already writes to disk.
- PLINK is natively three files (`.map`/`.ped`/`.pheno`); since the payload is a single string they're concatenated with `#### PLINK .map/.ped/.pheno ####` banner lines. Sex-specific recombination maps collapse to the female map in the combined payload.